### PR TITLE
Adds pytest with example test

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,9 @@ directory. To run the linter on a single file, run `flake8 dlme_airflow/path/to/
 To assist in passing the linter, use the [Black][BLK] opinionated code formatter
 by running `black dlme_airflow/path/to/file.py`.
 
+### Running Tests
+To run the entire test suite from the root directory, `PYTHONPATH=dlme_airflow pytest`.
+You can also run individual tests with `PYTHONPATH=dlme_airflow pytest tests/path/to/test.py`.
+
 [BLK]: https://black.readthedocs.io/en/stable/index.html
 [FLK8]: https://flake8.pycqa.org/en/latest/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ lxml >= 4.6.3
 Sickle >= 0.7.0
 flake8 >= 3.9.2
 black >= 21.7b0
+pytest >= 6.2.4

--- a/tests/harvester/test_copydir.py
+++ b/tests/harvester/test_copydir.py
@@ -9,17 +9,19 @@ def test_copydir(monkeypatch, tmp_path):
     @param tmp_path -- pytest fixture
     """
 
+    secs_since_epoch = 1628113477.966395
+
     def copytree(src, dst):
-        dst = tmp_path / "1628113477.966395"
+        dst = tmp_path / str(secs_since_epoch)
         dst.touch()
         return dst
 
     def time():
-        return 1628113477.966395
+        return secs_since_epoch
 
     monkeypatch.setattr("time.time", time)
 
     monkeypatch.setattr("shutil.copytree", copytree)
 
     copydir(provider="aims")
-    assert (tmp_path / "1628113477.966395").exists()
+    assert (tmp_path / str(secs_since_epoch)).exists()

--- a/tests/harvester/test_copydir.py
+++ b/tests/harvester/test_copydir.py
@@ -1,0 +1,25 @@
+from harvester.copydir import copydir
+
+
+def test_copydir(monkeypatch, tmp_path):
+    """Mocks standard library's shutil.copytree and time.time to test
+    copydir functionality
+
+    @param monkeypatch -- pytest mocking object
+    @param tmp_path -- pytest fixture
+    """
+
+    def copytree(src, dst):
+        dst = tmp_path / "1628113477.966395"
+        dst.touch()
+        return dst
+
+    def time():
+        return 1628113477.966395
+
+    monkeypatch.setattr("time.time", time)
+
+    monkeypatch.setattr("shutil.copytree", copytree)
+
+    copydir(provider="aims")
+    assert (tmp_path / "1628113477.966395").exists()


### PR DESCRIPTION
Fixes #10 

Created an example unit test for the `copydir` module using [pytest][PYTEST] mocking and using a temporary path. 

Updated README with directions on using [pytest][PYTEST].

[PYTEST]: https://docs.pytest.org/en/6.2.x/ 