### PR TITLE
Add git to the docker image so it is available to the BashOperator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
 FROM apache/airflow:2.1.2-python3.8
 
+USER root
+RUN apt-get -y update && apt-get -y install git
+USER airflow
+
 COPY --chown=airflow:root ./dlme_airflow /opt/dlme_airflow


### PR DESCRIPTION
This install git into the docker image so that it is available within Airflow and BashOperators. This will be necessary for cloning metadata and pushing changes.