### PR TITLE
Initial CSV Harvester 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,4 @@ RUN apt-get -y update && apt-get -y install git
 USER airflow
 
 COPY --chown=airflow:root ./dlme_airflow /opt/dlme_airflow
+COPY --chown=airflow:root catalog.yaml /opt/airflow/catalog.yaml

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -11,16 +11,46 @@ sources:
       csv_kwargs:
         blocksize: null
         dtype:
-          Artist: object
+          URI: object
+          Title: object
+          RecordId: object
+          Coin Type URI: object
           From Date: float64
-          Maker: object
-          Manufacture: object
-          Reference: object
+          To Date: float64
+          Artist: object
           SubjectEvent: object
           SubjectIssuer: object
           SubjectPerson: object
           SubjectPlace: object
-          To Date: float64
+          Authority: object
+          Coin Type: object
+          Degree: float64
+          Deity: object
+          Denomination: object
+          Department: object
+          Dynasty: object
+          Engraver: float64
+          Maker: object
+          Manufacture: object
+          Material: object
+          Mint: object
+          Object Type: object
+          Portrait: object
+          Reference: object
+          Region: object
+          Script: object
+          State: object
+          Obverse Legend: object
+          Obverse Type: object
+          Date on Object: float64
+          Ah: float64
+          Axis: float64
+          Diameter: float64
+          Weight: float64
+          Thumbnail_obv: object
+          Thumbnail_rev: object
+          Date Record Modified: object
+
       urlpath:
         - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=1'
         - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=1001'
@@ -35,32 +65,77 @@ sources:
     driver: csv
     metadata:
       current:
-        - "penn/egyptian-museum/data/egyptian-20181028-cleaned.csv"
+        - "{{ CATALOG_DIR }}../dlme-metadata/penn/egyptian-museum/data/egyptian-20181028-cleaned.csv"
     args:
       urlpath:
         - 'http://www.penn.museum/collections/assets/data/egyptian-csv-latest.zip'
         - 'http://www.penn.museum/collections/assets/data/near-eastern-csv-latest.zip'
       csv_kwargs:
         dtype:
-          creator: object
-          culture_area: object
+          emuIRN: int64
+          curatorial_section: object
+          object_number: object
+          object_name: object
+          native_name: object
+          culture: object
+          provenience: object
+          material: object
+          period: object
+          date_made: object
           date_made_early: object
           date_made_late: object
-          native_name: object
+          accession_credit_line: object
+          creator: object
+          description: object
+          manufacture_locationlocus: float64
+          culture_area: object
+          technique: object
+          iconography: object
+          measurement_height: float64
+          measurement_length: float64
+          measurement_width: float64
+          measurement_outside_diameter: float64
+          measurement_tickness: float64
+          measurement_unit: object
+          other_numbers: object
+          url: object
+
   yale_babylonian:
     description: 'Yale Babylonian Collection'
     driver: csv
     metadata:
       current:
-        - yale/babylonian/data/yale-babylonian.csv
+        - "{{ CATALOG_DIR }}../dlme-metadata/yale/babylonian/data/yale-babylonian.csv"
     args:
       csv_kwargs:
         blocksize: null
         dtype:
+          id: int64
+          occurrence_id: object
+          last_modified: object
+          callnumber: object
+          title: object
+          scientificname: object
+          collector: float64
+          collecting_date: float64
+          latitude: float64
+          longitude: float64
           datum: object
+          geographic_continent: object
+          geographic_country: object
+          geographic_stateprovince: object
           geographic_county: object
           geographic_municipality: object
-          scientificname: object
+          geographic_locality: float64
+          common_name: float64
+          type: object
+          format: object
+          era: object
+          geographic_culture: object
+          identified_by: object
+          identification_references: float64
+          previous_identifications: float64
+          associated_references: float64
       urlpath:
         - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=1&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
         - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=2&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -1,0 +1,83 @@
+metadata:
+  version: 1
+sources:
+  ans:
+    description: "American Numismatic Society"
+    driver: csv
+    metadata:
+      current:
+        - "{{ CATALOG_DIR }}/../dlme-metadata/american-numismatic-society/data/american-numismatic-society.csv"
+    args:
+      csv_kwargs:
+        blocksize: null
+        dtype:
+          Artist: object
+          From Date: float64
+          Maker: object
+          Manufacture: object
+          Reference: object
+          SubjectEvent: object
+          SubjectIssuer: object
+          SubjectPerson: object
+          SubjectPlace: object
+          To Date: float64
+      urlpath:
+        - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=1'
+        - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=1001'
+        - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=2001'
+        - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=3001'
+        - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=4001'
+        - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=5001'
+        - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=6001'
+        - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=7001'
+  penn_egyptian_museum:
+    description: "University of Pennsylvania Egyptian Museum"
+    driver: csv
+    metadata:
+      current:
+        - "penn/egyptian-museum/data/egyptian-20181028-cleaned.csv"
+    args:
+      urlpath:
+        - 'http://www.penn.museum/collections/assets/data/egyptian-csv-latest.zip'
+        - 'http://www.penn.museum/collections/assets/data/near-eastern-csv-latest.zip'
+      csv_kwargs:
+        dtype:
+          creator: object
+          culture_area: object
+          date_made_early: object
+          date_made_late: object
+          native_name: object
+  yale_babylonian:
+    description: 'Yale Babylonian Collection'
+    driver: csv
+    metadata:
+      current:
+        - yale/babylonian/data/yale-babylonian.csv
+    args:
+      csv_kwargs:
+        blocksize: null
+        dtype:
+          datum: object
+          geographic_county: object
+          geographic_municipality: object
+          scientificname: object
+      urlpath:
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=1&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=2&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=3&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=4&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=5&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=6&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=7&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=8&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=9&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=10&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=11&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=12&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=13&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=14&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=15&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=16&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=17&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=18&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'
+        - 'https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=19&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv'

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -6,7 +6,7 @@ sources:
     driver: csv
     metadata:
       current:
-        - "{{ CATALOG_DIR }}/../dlme-metadata/american-numismatic-society/data/american-numismatic-society.csv"
+        - "{{ CATALOG_DIR }}../dlme-metadata/american-numismatic-society/data/american-numismatic-society.csv"
     args:
       csv_kwargs:
         blocksize: null

--- a/dlme_airflow/dags/intake_harvester.py
+++ b/dlme_airflow/dags/intake_harvester.py
@@ -1,10 +1,9 @@
 from airflow import DAG
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from harvester.csv import csv_harvester
 
 from airflow.operators.python import PythonOperator
-from airflow.utils.dates import days_ago
 
 
 default_args = {
@@ -23,8 +22,9 @@ with DAG(
     default_args=default_args,
     description="Intake Harvester DAG",
     schedule_interval=timedelta(days=1),
-    start_date=days_ago(2),
+    start_date=datetime(2021, 8, 17),
     tags=["csv"],
+    catchup=False
 ) as dag:
     t1 = PythonOperator(
         task_id="csv_harvester",

--- a/dlme_airflow/dags/intake_harvester.py
+++ b/dlme_airflow/dags/intake_harvester.py
@@ -1,0 +1,36 @@
+from airflow import DAG
+from datetime import timedelta
+
+from harvester.csv import csv_harvester
+
+from airflow.operators.python import PythonOperator
+from airflow.utils.dates import days_ago
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email": ["airflow@example.com"],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "provider": None,
+}
+
+with DAG(
+    "intake-harvester",
+    default_args=default_args,
+    description="Intake Harvester DAG",
+    schedule_interval=timedelta(days=1),
+    start_date=days_ago(2),
+    tags=["csv"],
+) as dag:
+    t1 = PythonOperator(
+        task_id="csv_harvester",
+        python_callable=csv_harvester,
+        op_kwargs={"provider": "{{ dag_run.conf['provider'] }}"},
+    )
+
+
+t1

--- a/dlme_airflow/harvester/aims.py
+++ b/dlme_airflow/harvester/aims.py
@@ -10,8 +10,7 @@ from io import BytesIO
 
 def oai():
     parser = etree.XMLParser(ns_clean=True, load_dtd=False)
-    xml = requests.get(
-        "https://feed.podbean.com/themaghribpodcast/feed.xml").content
+    xml = requests.get("https://feed.podbean.com/themaghribpodcast/feed.xml").content
     tree = etree.parse(BytesIO(xml), parser)
     directory = "/opt/airflow/output/aims/data/"
     os.makedirs(os.path.dirname(directory), exist_ok=True)

--- a/dlme_airflow/harvester/csv.py
+++ b/dlme_airflow/harvester/csv.py
@@ -1,9 +1,20 @@
-import time
+import logging
 
 import intake
 import pandas as pd
 
 catalog = intake.open_catalog("catalog.yaml")
+
+
+def check_equality(harvested_df: pd.DataFrame, saved_df: pd.DataFrame):
+    """Checks for DataFrame equality between latest harvested data with
+    persisted DataFrame.
+
+    @param -- harvested_df
+    @param -- saved_df
+    """
+    if not saved_df.equals(harvested_df):
+        logging.error("harvested dataframe does not equal saved dataframe")
 
 
 def csv_harvester(provider: str):
@@ -12,11 +23,14 @@ def csv_harvester(provider: str):
 
     @param provider -- Data provider
     """
+    logging.info(f"Started csv harvest for {provider}")
     if provider not in catalog:
         raise ValueError(f"{provider} not found in catalog")
     csv_source = getattr(catalog, provider)
     csv_df = csv_source.read()
-    existing_df = pd.concat([pd.read_csv(r) for r in csv_source.metadata.get('current')])
-    if csv_df.equals(existing_df) is False:
-        raise ValueError(f"Harvested {provider} differs from existing")
-    return csv_source
+    existing_df = pd.concat(
+        [pd.read_csv(r) for r in csv_source.metadata.get("current")]
+    )
+    logging.info(f"{provider} start check_equality")
+    check_equality(existing_df, csv_df)
+    logging.info(f"{provider} finished check equality")

--- a/dlme_airflow/harvester/csv.py
+++ b/dlme_airflow/harvester/csv.py
@@ -1,0 +1,22 @@
+import time
+
+import intake
+import pandas as pd
+
+catalog = intake.open_catalog("catalog.yaml")
+
+
+def csv_harvester(provider: str):
+    """CSV Harvester takes a YAML configuration file, loads a csv file from a
+    URL or filesystem, and returns the result as a Pandas Dataframe
+
+    @param provider -- Data provider
+    """
+    if provider not in catalog:
+        raise ValueError(f"{provider} not found in catalog")
+    csv_source = getattr(catalog, provider)
+    csv_df = csv_source.read()
+    existing_df = pd.concat([pd.read_csv(r) for r in csv_source.metadata.get('current')])
+    if csv_df.equals(existing_df) is False:
+        raise ValueError(f"Harvested {provider} differs from existing")
+    return csv_source

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,7 +59,7 @@ x-airflow-common:
     AIRFLOW_VAR_DATA_MANAGER_EMAIL: 'amcollie@stanford.edu'
     AIRFLOW_VAR_GIT_BRANCH: 'main'
     AIRFLOW_VAR_GIT_REPO_METADATA: 'https://github.com/sul-dlss/dlme-metadata.git'
-    _PIP_ADDITIONAL_REQUIREMENTS: 'lxml sickle' # ${_PIP_ADDITIONAL_REQUIREMENTS:-}
+    _PIP_ADDITIONAL_REQUIREMENTS: 'lxml sickle intake aiohttp' # ${_PIP_ADDITIONAL_REQUIREMENTS:-}
     PYTHONPATH: '$PYTHONPATH:/opt/dlme_airflow'
   volumes:
     - ./logs:/opt/airflow/logs

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Sickle >= 0.7.0
 flake8 >= 3.9.2
 black >= 21.7b0
 pytest >= 6.2.4
+intake >= 0.6.2
+aiohttp >= 3.7.4.post0

--- a/tests/harvester/test_csv.py
+++ b/tests/harvester/test_csv.py
@@ -1,0 +1,13 @@
+import pytest
+from harvester.csv import csv_harvester
+
+
+def test_csv_harvester(monkeypatch, tmp_path):
+    ans_source = csv_harvester("ans")
+    assert ans_source.metadata
+    assert csv_harvester is not None
+
+
+def test_provider_not_found():
+    with pytest.raises(ValueError, match=r"bad_provider not found in catalog"):
+        csv_harvester("bad_provider")

--- a/tests/harvester/test_csv.py
+++ b/tests/harvester/test_csv.py
@@ -1,13 +1,32 @@
+import logging
 import pytest
-from harvester.csv import csv_harvester
+import pandas as pd
+from harvester.csv import csv_harvester, check_equality
+
+LOGGER = logging.getLogger(__name__)
 
 
-def test_csv_harvester(monkeypatch, tmp_path):
-    ans_source = csv_harvester("ans")
-    assert ans_source.metadata
-    assert csv_harvester is not None
+def test_csv_harvester(caplog):
+    assert csv_harvester
+    # TODO: Need to mock dlme-metadata
 
 
 def test_provider_not_found():
     with pytest.raises(ValueError, match=r"bad_provider not found in catalog"):
         csv_harvester("bad_provider")
+
+
+def test_check_equality_pass(caplog):
+    harvested_df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    saved_df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    with caplog.at_level(logging.ERROR):
+        check_equality(harvested_df, saved_df)
+    assert "harvested dataframe does not equal saved dataframe" not in caplog.text
+
+
+def test_check_equality_fail(caplog):
+    harvested_df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    saved_df = pd.DataFrame({"col1": [1, 2], "col2": [4, 5]})
+    with caplog.at_level(logging.ERROR):
+        check_equality(harvested_df, saved_df)
+    assert "harvested dataframe does not equal saved dataframe" in caplog.text


### PR DESCRIPTION
Fixes #2 

WIP PR uses [Intake](https://intake.readthedocs.io/en/latest/index.html) to configure three csv data-sources `ans`, `penn_egyptian_museum`, and `yale_babylonian` in a catalog.yml. Not sure we actually need a separate csv_harvester function as I think we can directly call the Intake catalog from the respective dags but leaving the function and tests for now. 

Includes new `intake_harvester` DAG that requires a provider configuration to be set per run in Airflow. I think in a follow-up we may have a list of providers or other way to do this harvesting and validation. 
