### PR TITLE
JSON IIIF Intake Driver 

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -60,6 +60,18 @@ sources:
         - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=5001'
         - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=6001'
         - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=7001'
+  auc_iiif:
+    args:
+      path: catalogs/auc_iiif.yaml
+    description: "American University in Cairo IIIf Collections"
+    driver: intake.catalog.local.YAMLFileCatalog
+    metadata: {}
+  bodleian:
+    args:
+      path: catalogs/bodleian.yaml
+    description: "Bodleian Libraries, University of Oxford"
+    driver: intake.catalog.local.YAMLFileCatalog
+    metadata: {}
   penn_egyptian_museum:
     description: "University of Pennsylvania Egyptian Museum"
     driver: csv

--- a/catalogs/auc_iiif.yaml
+++ b/catalogs/auc_iiif.yaml
@@ -46,3 +46,939 @@ sources:
         title: object
         type: object
         repository: object
+  alexandria_bombardment:
+    description: "Alexandria Bombardment of 1882 Photograph Album"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: "https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll9/manifest.json"
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        location: object
+        date-created: object
+        description: object
+        format: object
+        extent: object
+        medium: object
+        identifier: object
+        language: object
+        collection: object
+        access-rights: object
+        license: object
+        source: object
+        subject-lcsh: object
+        title: object
+        type: object
+        photographer: object
+        repository: object
+        name: object
+        subject-tgm: object
+        original-identifier: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/alexandria-bombardment/data/"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  bint_al_nil:
+    description: "Bint al-Nil Journal"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll19/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        description-arabic: object
+        creator: object
+        date: object
+        description-english: object
+        format: object
+        genre-aat: object
+        language: object
+        publisher: object
+        rights: object
+        source: object
+        subject: object
+        title-english: object
+        title-arabic: object
+        type: object
+        repository: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/bint-al-nil/data/"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  campus_photos:
+    description: "Art in the Greek Campus"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll32/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        buildings: object
+        coverage: object
+        creator: object
+        collection: object
+        date: object
+        description: object
+        format: object
+        getty-aat: object
+        identifier: object
+        license: object
+        physical-box-number: object
+        rights: object
+        source: object
+        subject: object
+        subseries: object
+        title: object
+        type: object
+        repository: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/campus-photos/data/"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  coptic:
+    description: "Iryan Moftah Coptic Language and Religion Manuscripts"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll4/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        acknowledgements: object
+        alternative-title: object
+        author: object
+        date-created: object
+        description: object
+        format: object
+        extent: object
+        medium: object
+        identifier: object
+        language: object
+        name: object
+        patron: object
+        collection: object
+        access-rights: object
+        license: object
+        source: object
+        subject-lcsh: object
+        title: object
+        type: object
+        scribe: object
+        repository: object
+        location: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/coptic/data/"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  fathy:
+    description: "Hassan Fathy Architectural Archives"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll13/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        collection: object
+        location-in-english: object
+        date-created: object
+        creator: object
+        access-rights: object
+        license: object
+        source: object
+        site: object
+        subject: object
+        title-in-english: object
+        title-in-arabic: object
+        repository: object
+        location-in-arabic: object
+        original-identifier: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/fathy/data/"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  hopkins:
+    description: "Nicholas S. Hopkins Rural Egypt Photographs"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll12/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        location: object
+        creator: object
+        date: object
+        format: object
+        genre-aat: object
+        source: object
+        identifier: object
+        rights: object
+        collection: object
+        subject: object
+        title: object
+        type: object
+        repository: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/hopkins/data/"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  islamic_aa:
+    description: "Islamic Art & Architecture Slides"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll30/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        access-rights: object
+        site: object
+        location: object
+        date-built: object
+        format: object
+        collection: object
+        medium: object
+        license: object
+        source: object
+        subject-lcsh: object
+        title: object
+        type: object
+        repository: object
+        subject-tgm: object
+        identifier: object
+        description: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/islamic-aa/data/"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  maps:
+    description: "Historic Maps Digital Collection"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll6/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        creator: object
+        date: object
+        description: object
+        digital-collection: object
+        identifier: object
+        language: object
+        license: object
+        publisher: object
+        rights: object
+        scale: object
+        source: object
+        subject: object
+        title: object
+        genre-aat: object
+        type: object
+        repository: object
+        coverage-spatial: object
+        format: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/maps/data/"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  maritz:
+    description: "Philip Maritz Collection of Émile Béchard's Photographs of Egypt"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll16/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        acknowledgments: object
+        alternative-title: object
+        access-rights: object
+        extent: object
+        location: object
+        photographer: object
+        date: object
+        format: object
+        identifier: object
+        language: object
+        getty-aat: object
+        collection: object
+        license: object
+        source: object
+        subject: object
+        title: object
+        type: object
+        repository: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/maritz/data"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  napoleonic_egypt:
+    description: "Napoleonic Egypt"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll2/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        location: object
+        creator: object
+        date: object
+        genre-aat: object
+        identifier: object
+        language: object
+        publisher: object
+        rights: object
+        source: object
+        subject: object
+        title: object
+        repository: object
+        alternative-title: object
+        description: object
+        collection: object
+        format: object
+        type: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/napoleonic-egypt/data"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  parker:
+    description: "Richard B. Parker Nile Watercraft Photographs"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll31/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        location: object
+        creator: object
+        date: object
+        format: object
+        genre-aat: object
+        identifier: object
+        license: object
+        collection: object
+        rights: object
+        source: object
+        subject: object
+        title: object
+        type: object
+        repository: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/parker/data"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  postcards:
+    description: "Egyptian Postcard Collection"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll21/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        access-rights: object
+        location: object
+        date: object
+        format: object
+        genre-aat: object
+        identifier: object
+        source: object
+        rights: object
+        collection: object
+        subject: object
+        title: object
+        type: object
+        repository: object
+        publisher: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/postcards/data"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  qurna:
+    description: "Qurna Hillside Oral History Project"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll24/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        coverage: object
+        interviewee: object
+        date: object
+        description: object
+        language: object
+        medium: object
+        license: object
+        rights: object
+        source: object
+        title: object
+        repository: object
+        format: object
+        identifier: object
+        publisher: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/qurna/data"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+          optional: true
+        profile:
+          path: 'sequences..profile'
+          optional: true
+        resource:
+          path: 'sequences..resource.@id'
+          optional: true
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  rare_books:
+    description: "Selections from the Rare Books and Special Collections Library"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll11/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        alternative-title: object
+        location: object
+        creator: object
+        date: object
+        genre-aat: object
+        language: object
+        publisher: object
+        rights: object
+        source: object
+        subject: object
+        title: object
+        type: object
+        repository: object
+        description: object
+        extent: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/rare-books/data"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  sphinx:
+    description: "The Sphinx"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/2/sphinx/p1.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        genre: object
+        coverage: object
+        date: object
+        format: object
+        language: object
+        publisher: object
+        access: object
+        rights: object
+        source: object
+        subject: object
+        title: object
+        type: object
+        repository: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/sphinx/data"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  taxiphote_slides:
+    description: "Taxiphote Slides"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll15/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        license: object
+        location: object
+        date: object
+        topic: object
+        format: object
+        identifier: object
+        language: object
+        medium: object
+        original-identifier: object
+        collection: object
+        rights: object
+        source: object
+        title: object
+        type: object
+        repository: object
+        subject: object
+        name: object
+        creator: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/taxiphote-slides/data"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  underwood:
+    description: ""
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll8/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        acknowledgements: object
+        location: object
+        date-created: object
+        description: object
+        format: object
+        extent: object
+        medium: object
+        identifier: object
+        language: object
+        original-identifier: object
+        collection: object
+        access-rights: object
+        license: object
+        source: object
+        subject: object
+        topic: object
+        title: object
+        type: object
+        publisher: object
+        repository: object
+        architectural-detail: object
+        name: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/underwood/data/"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  university_on_the_square:
+    description: "University on the Square, Documenting Egypt's 21st Century Revolution"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll7/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        acknowledgements: object
+        photographer: object
+        location: object
+        date-created: object
+        date-submitted: object
+        description: object
+        format: object
+        extent: object
+        medium: object
+        identifier: object
+        collection: object
+        access-rights: object
+        license: object
+        source: object
+        subject-tgm: object
+        subject-lcsh: object
+        title: object
+        type: object
+        repository: object
+        language: object
+        name: object
+        contributor: object
+        artist: object
+        age: object
+        egyptian-national?: object
+        gender: object
+        occupation: object
+        relationship-to-auc: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/university-on-the-square/data/"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+  wassef:
+    description: ""
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll5/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        acknowledgements: object
+        collection: object
+        location: object
+        architect: object
+        date-created: object
+        extent: object
+        medium: object
+        identifier: object
+        access-rights: object
+        license: object
+        source: object
+        subject-lcsh: object
+        title: object
+        repository: object
+        format: object
+        original-identifier: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/wassef/data"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true

--- a/catalogs/auc_iiif.yaml
+++ b/catalogs/auc_iiif.yaml
@@ -1,0 +1,48 @@
+metadata:
+  version: 1
+sources:
+  al_musawwar:
+    description: "Al-Musawwar Magazine Collection"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/auc/iiif/al-musawwar/data/"
+      fields:
+        context:
+          path: '@context'
+          optional: true
+        description_top:
+          path: 'description'
+          optional: true
+        id:
+          path: '@id'
+          optional: true
+        iiif_format:
+          path: 'sequences..format'
+        profile:
+          path: 'sequences..profile'
+        resource:
+          path: 'sequences..resource.@id'
+        thumbnail:
+          path: 'thumbnail..@id'
+          optional: true
+    args:
+      collection_url: https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll29/manifest.json
+      dtype:
+        context: object
+        id: object
+        iiif_format: object
+        profile: object
+        resource: object
+        genre: object
+        coverage: object
+        date: object
+        format: object
+        language: object
+        publisher: object
+        access: object
+        rights: object
+        source: object
+        subject: object
+        title: object
+        type: object
+        repository: object

--- a/catalogs/bodleian.yaml
+++ b/catalogs/bodleian.yaml
@@ -1,0 +1,32 @@
+metadata:
+  version: 1
+sources:
+  exploring_egypt:
+    description: "Exploring Egypt in the 19th Century"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://iiif.bodleian.ox.ac.uk/iiif/collection/exploring-egypt
+      dtype:
+        description: object
+        rendering: object
+        thumbnail: object
+        homepage: object
+        title: object
+        shelfmark: object
+        author: object
+        language: object
+        date-statement: object
+        extent: object
+        subject: object
+        other-identifier: object
+        record-created: object
+        holding-institution: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/bodleian/exploring-egypt/data/"
+      fields:
+        description:
+          path: "description"
+        rendering:
+          path: "rendering..@id"
+        thumbnail:
+          path: "thumbnail..@id"

--- a/catalogs/bodleian.yaml
+++ b/catalogs/bodleian.yaml
@@ -1,6 +1,57 @@
 metadata:
   version: 1
 sources:
+  arabic:
+    description: "Items of Arabic origin"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://iiif.bodleian.ox.ac.uk/iiif/collection/arabic-origin
+      dtype:
+        description: object
+        rendering: object
+        thumbnail: object
+        homepage: object
+        catalogue-description: object
+        title: object
+        other-titles: object
+        shelfmark: object
+        language: object
+        extent: object
+        record-origin: object
+        collection: object
+        record-created: object
+        holding-institution: object
+        digitization-sponsor: object
+        author: object
+        date-statement: object
+        place-of-origin: object
+        provenance: object
+        acknowledgements: object
+        materials: object
+        slide-roll-title: object
+        digitization-project: object
+        translator: object
+        editors: object
+        scribe: object
+        former-owner: object
+        contents-note: object
+        layout: object
+        hand: object
+        dimensions: object
+        decoration: object
+        binding: object
+        origin-note: object
+        catalogue-identifier: object
+        contents: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/bodleian/arabic/data/"
+      fields:
+        description:
+          path: "description"
+        rendering:
+          path: "rendering..@id"
+        thumbnail:
+          path: "thumbnail..@id"
   exploring_egypt:
     description: "Exploring Egypt in the 19th Century"
     driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
@@ -23,6 +74,155 @@ sources:
         holding-institution: object
     metadata:
       current_directory: "{{ CATALOG_DIR }}../dlme-metadata/bodleian/exploring-egypt/data/"
+      fields:
+        description:
+          path: "description"
+        rendering:
+          path: "rendering..@id"
+        thumbnail:
+          path: "thumbnail..@id"
+  hebrew:
+    description: "Items of Hebrew origin"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://iiif.bodleian.ox.ac.uk/iiif/collection/hebrew-origin
+      dtype:
+        description: object
+        rendering: object
+        thumbnail: object
+        homepage: object
+        title: object
+        shelfmark: object
+        printer: object
+        language: object
+        date-statement: object
+        place-of-origin: object
+        collection: object
+        digitization-project: object
+        record-created: object
+        holding-institution: object
+        catalogue-identifier: object
+        author: object
+        translator: object
+        catalogue-description: object
+        scribe: object
+        slide-roll-title: object
+        provenance: object
+        materials: object
+        hand: object
+        editors: object
+        commentators: object
+        former-owner: object
+        other-titles: object
+        contents-note: object
+        layout: object
+        extent: object
+        dimensions: object
+        binding: object
+        record-origin: object
+        additional-information-sources: object
+        related-items: object
+        decoration: object
+        compiler: object
+        digitization-note: object
+        contents: object
+        author-of-introduction: object
+        other-identifier: object
+        acknowledgements: object
+        digitization-sponsor: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/bodleian/hebrew/data/"
+      fields:
+        description:
+          path: "description"
+        rendering:
+          path: "rendering..@id"
+        thumbnail:
+          path: "thumbnail..@id"
+  persian:
+    description: "Items of Persian origin"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://iiif.bodleian.ox.ac.uk/iiif/collection/persian-origin
+      dtype:
+        description: object
+        rendering: object
+        thumbnail: object
+        homepage: object
+        title: object
+        shelfmark: object
+        author: object
+        language: object
+        place-of-origin: object
+        record-created: object
+        holding-institution: object
+        catalogue-description: object
+        other-titles: object
+        scribe: object
+        date-statement: object
+        hand: object
+        extent: object
+        dimensions: object
+        decoration: object
+        record-origin: object
+        collection: object
+        catalogue-identifier: object
+        former-owner: object
+        materials: object
+        contents: object
+        contributor: object
+        binding: object
+        provenance: object
+        digitization-sponsor: object
+        illustrator: object
+        contents-note: object
+        related-items: object
+        editors: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/bodleian/persian/data/"
+      fields:
+        description:
+          path: "description"
+        rendering:
+          path: "rendering..@id"
+        thumbnail:
+          path: "thumbnail..@id"
+  turkish:
+    description: "Items of Turkish origin"
+    driver: dlme_airflow.drivers.iiif_json.IIIfJsonSource
+    args:
+      collection_url: https://iiif.bodleian.ox.ac.uk/iiif/collection/turkish-origin
+      dtype:
+        description: object
+        rendering: object
+        thumbnail: object
+        homepage: object
+        catalogue-description: object
+        title: object
+        other-titles: object
+        shelfmark: object
+        author: object
+        scribe: object
+        language: object
+        date-statement: object
+        place-of-origin: object
+        hand: object
+        extent: object
+        record-origin: object
+        collection: object
+        catalogue-identifier: object
+        record-created: object
+        holding-institution: object
+        digitization-sponsor: object
+        materials: object
+        dimensions: object
+        decoration: object
+        related-items: object
+        binding: object
+        provenance: object
+        contents: object
+    metadata:
+      current_directory: "{{ CATALOG_DIR }}../dlme-metadata/bodleian/turkish/data/"
       fields:
         description:
           path: "description"

--- a/dlme_airflow/drivers/iiif_json.py
+++ b/dlme_airflow/drivers/iiif_json.py
@@ -1,0 +1,72 @@
+import logging
+import intake
+import requests
+import jsonpath_ng
+import pandas as pd
+
+
+class IIIfJsonSource(intake.source.base.DataSource):
+    container = "dataframe"
+    name = "iiif_json"
+    version = "0.0.1"
+
+    def __init__(self, collection_url, dtype=None, metadata=None):
+        super(IIIfJsonSource, self).__init__(metadata=metadata)
+        self.collection_url = collection_url
+        self.dtype = dtype
+        self._manifest_urls = []
+        self._path_expressions = {}
+
+    def _open_collection(self):
+        collection_result = requests.get(self.collection_url)
+        for manifest in collection_result.json().get("manifests", []):
+            self._manifest_urls.append(manifest.get("@id"))
+
+    def _open_manifest(self, manifest_url):
+        manifest_result = requests.get(manifest_url)
+        manifest_detail = manifest_result.json()
+        record = self._construct_fields(manifest_detail)
+        # Handles metadata in IIIf manfest
+        record.update(self._from_metadata(manifest_detail.get("metadata", [])))
+        return record
+
+    def _construct_fields(self, manifest):
+        output = {}
+        for name, info in self.metadata.get("fields").items():
+            expression = self._path_expressions.get(name)
+            result = [match.value for match in expression.find(manifest)]
+            if len(result) < 1:
+                if info.get("optional") is True:
+                    # Skip and continue
+                    continue
+                else:
+                    logging.warn(f"{manifest.get('@id')} missing {name}")
+            else:
+                output[name] = result[0]  # Use first value
+        return output
+
+    def _from_metadata(self, metadata):
+        output = {}
+        for row in metadata:
+            name = row.get('label').replace(" ", "-").lower().replace("(", "").replace(")", "")
+            if name in output:
+                output[name].append(row.get('value'))
+            else:
+                output[name] = [row.get('value')]
+        return output
+
+    def _get_schema(self):
+        for name, info in self.metadata.get("fields", {}).items():
+            self._path_expressions[name] = jsonpath_ng.parse(info.get("path"))
+        self._open_collection()
+        return intake.source.base.Schema(
+            datashape=None,
+            dtype=self.dtype,
+            shape=None,
+            npartitions=len(self._manifest_urls),
+            extra_metadata={},
+        )
+
+    def read(self):
+        self._load_metadata()
+        return pd.DataFrame([self._open_manifest(url) for url in self._manifest_urls])

--- a/dlme_airflow/harvester/csv.py
+++ b/dlme_airflow/harvester/csv.py
@@ -3,18 +3,9 @@ import logging
 import intake
 import pandas as pd
 
+from harvester.validations import check_equality
+
 catalog = intake.open_catalog("catalog.yaml")
-
-
-def check_equality(harvested_df: pd.DataFrame, saved_df: pd.DataFrame):
-    """Checks for DataFrame equality between latest harvested data with
-    persisted DataFrame.
-
-    @param -- harvested_df
-    @param -- saved_df
-    """
-    if not saved_df.equals(harvested_df):
-        logging.error("harvested dataframe does not equal saved dataframe")
 
 
 def csv_harvester(provider: str):

--- a/dlme_airflow/harvester/iiif_json.py
+++ b/dlme_airflow/harvester/iiif_json.py
@@ -1,0 +1,36 @@
+import logging
+import pathlib
+
+# import time
+
+import intake
+import pandas as pd
+
+from harvester.validations import check_equality
+
+catalog = intake.open_catalog("catalog.yaml")
+
+
+def iiif_json_harvester(provider: str):
+    """IIIf JSON harvester, takes a provider (for nested catalog use the catalog
+    name.source, i.e. bodleian.arabic) extracts and
+
+    @param -- provider
+    """
+    logging.info(f"Started iiif JSON harvest for {provider}")
+    if provider not in catalog:
+        raise ValueError(f"{provider} not found in catalog")
+    source = getattr(catalog, provider)
+    source_df = source.read()
+    existing_directory = pathlib.Path(source.metadata.current_directory)
+    existing_df = pd.concat(
+        [pd.read_json(json_path) for json_path in existing_directory.glob("*.json")]
+    )
+    logging.info(f"{provider} start check_equality")
+    check_equality(existing_df, source_df)
+    logging.info(f"{provider} finished check equality")
+    # Pattern for persisting DataFrame to the local container, we could
+    # get the directory from the config
+    # source_df_path = f"/opt/airflow/{provider}-{time.time()}.csv"
+    # logging.info(f"persisting to {source_df_path}")
+    # source_df.to_csv(source_df_path)

--- a/dlme_airflow/harvester/validations.py
+++ b/dlme_airflow/harvester/validations.py
@@ -1,0 +1,14 @@
+import logging
+
+import pandas as pd
+
+
+def check_equality(harvested_df: pd.DataFrame, saved_df: pd.DataFrame):
+    """Checks for DataFrame equality between latest harvested data with
+    persisted DataFrame.
+
+    @param -- harvested_df
+    @param -- saved_df
+    """
+    if not saved_df.equals(harvested_df):
+        logging.error("harvested dataframe does not equal saved dataframe")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ black >= 21.7b0
 pytest >= 6.2.4
 intake >= 0.6.2
 aiohttp >= 3.7.4.post0
+jsonpath_ng >= 1.5.3

--- a/tests/drivers/test_iiif_json.py
+++ b/tests/drivers/test_iiif_json.py
@@ -1,0 +1,92 @@
+import pytest
+import requests
+import pandas as pd
+
+from drivers.iiif_json import IIIfJsonSource
+
+
+class MockIIIFCollectionResponse:
+    @staticmethod
+    def json():
+        return {
+            "manifests": [
+                {"@id": "https://collection.edu/iiif/p15795coll29:28/manifest.json"}
+            ]
+        }
+
+
+class MockIIIFManifestResponse:
+    @staticmethod
+    def json():
+        return {
+            "@context": "http://iiif.io/api/presentation/2/context.json",
+            "@id": "https://collection.edu/iiif/p15795coll29:28/manifest.json",
+            "metadata": [
+                {
+                    "label": "Source",
+                    "value": "Rare Books and Special Collections Library",
+                },
+                {"label": "Title (main)", "value": "A great title of the Middle East"},
+            ],
+            "sequences": [
+                {"canvases": [{"images": [{"resource": {"format": "image/jpeg"}}]}]}
+            ],
+        }
+
+
+@pytest.fixture
+def mock_response(monkeypatch):
+    def mock_get(*args, **kwargs):
+        if args[0].endswith("collection.json"):
+            return MockIIIFCollectionResponse()
+        if args[0].endswith("manifest.json"):
+            return MockIIIFManifestResponse()
+        return
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+
+@pytest.fixture
+def iiif_test_source():
+    metadata = {
+        "fields": {
+            "context": {"path": "@context", "optional": True},
+            "iiif_format": {"path": "sequences..format"},
+        }
+    }
+    return IIIfJsonSource(
+        collection_url="http://iiif_collection.json", metadata=metadata
+    )
+
+
+def test_IIIfJsonSource_initial(iiif_test_source, mock_response):
+    assert len(iiif_test_source._manifest_urls) == 0
+
+
+def test_IIIfJsonSource_get_schema(iiif_test_source, mock_response):
+    iiif_test_source._get_schema()
+    assert (
+        iiif_test_source._manifest_urls[0]
+        == "https://collection.edu/iiif/p15795coll29:28/manifest.json"
+    )
+
+
+def test_IIIfJsonSource_read(iiif_test_source, mock_response):
+    iiif_df = iiif_test_source.read()
+    test_columns = ["context", "iiif_format", "source", "title-main"]
+    assert all([a == b for a, b in zip(iiif_df.columns, test_columns)])
+
+
+def test_test_IIIfJsonSource_df(iiif_test_source, mock_response):
+    iiif_df = iiif_test_source.read()
+    test_df = pd.DataFrame(
+        [
+            {
+                "context": "http://iiif.io/api/presentation/2/context.json",
+                "iiif_format": "image/jpeg",
+                "source": ["Rare Books and Special Collections Library"],
+                "title-main": ["A great title of the Middle East"],
+            }
+        ]
+    )
+    assert iiif_df.equals(test_df)

--- a/tests/harvester/test_csv.py
+++ b/tests/harvester/test_csv.py
@@ -1,12 +1,9 @@
-import logging
 import pytest
-import pandas as pd
-from harvester.csv import csv_harvester, check_equality
 
-LOGGER = logging.getLogger(__name__)
+from harvester.csv import csv_harvester
 
 
-def test_csv_harvester(caplog):
+def test_csv_harvester():
     assert csv_harvester
     # TODO: Need to mock dlme-metadata
 
@@ -14,19 +11,3 @@ def test_csv_harvester(caplog):
 def test_provider_not_found():
     with pytest.raises(ValueError, match=r"bad_provider not found in catalog"):
         csv_harvester("bad_provider")
-
-
-def test_check_equality_pass(caplog):
-    harvested_df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
-    saved_df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
-    with caplog.at_level(logging.ERROR):
-        check_equality(harvested_df, saved_df)
-    assert "harvested dataframe does not equal saved dataframe" not in caplog.text
-
-
-def test_check_equality_fail(caplog):
-    harvested_df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
-    saved_df = pd.DataFrame({"col1": [1, 2], "col2": [4, 5]})
-    with caplog.at_level(logging.ERROR):
-        check_equality(harvested_df, saved_df)
-    assert "harvested dataframe does not equal saved dataframe" in caplog.text

--- a/tests/harvester/test_iiif_json_harvester.py
+++ b/tests/harvester/test_iiif_json_harvester.py
@@ -1,0 +1,12 @@
+import pytest
+
+from harvester.iiif_json import iiif_json_harvester
+
+
+def test_iiif_json_harvester():
+    assert iiif_json_harvester
+
+
+def test_provider_not_found():
+    with pytest.raises(ValueError, match=r"bad_provider not found in catalog"):
+        iiif_json_harvester("bad_provider")

--- a/tests/harvester/test_validation.py
+++ b/tests/harvester/test_validation.py
@@ -1,0 +1,22 @@
+import logging
+import pandas as pd
+
+from harvester.validations import check_equality
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_check_equality_pass(caplog):
+    harvested_df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    saved_df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    with caplog.at_level(logging.ERROR):
+        check_equality(harvested_df, saved_df)
+    assert "harvested dataframe does not equal saved dataframe" not in caplog.text
+
+
+def test_check_equality_fail(caplog):
+    harvested_df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    saved_df = pd.DataFrame({"col1": [1, 2], "col2": [4, 5]})
+    with caplog.at_level(logging.ERROR):
+        check_equality(harvested_df, saved_df)
+    assert "harvested dataframe does not equal saved dataframe" in caplog.text


### PR DESCRIPTION
Partially implements #3.

This PR creates a new class `IIIfJsonSource` that extends `intake.source.base.DataSource` and also implements two nested Catalogs for the American University of Cairo and the Bodleian Library at Oxford University. For a IIIf JSON source, there is one required argument, `collection_url` and optional `dtype` and `metadata` arguments. The `dtype` argument species the types in the resulting Panda's DataFrame. The implementation first downloads the JSON payload from `collection_url` and parses out all of the individual manifest URLs. When a `IIIfJsonSource` instance's `.read()` method is called, each manifest URL is retrieved and the fields (see below for `field` definition) are saved a Pandas DataFrame is returned with the results. 

The `metadata` argument has two top-level elements, the `current_directory` which should point to the **dlme-metadata** data directory for a collection, and a `fields` elements contain the field name followed by a [JSON Path](https://goessner.net/articles/JsonPath/) to extract a value from the IIIf JSON. 

**NOTE:** The IIIF Manifest `metadata` field does not to be defined in the `fields` because all of the label-values are extracted, the label is normalized as a key, and assigned a value. Unlike the dlme-harvester scripts the Driver was based on, all values associated with a particular name are saved in a list not overwritten by the last occurrence of the name in the dictionary.

To finish this PR:
- [x] Tests for the `IIIfJsonSource` driver 
- [x] Remaining IIIf sources added to new or existing catalogs
- [x] IIIF JSON Harvester