### PR TITLE
Implements _get_partition method in IIIF JSON Harvester

### DIFF
--- a/dlme_airflow/drivers/iiif_json.py
+++ b/dlme_airflow/drivers/iiif_json.py
@@ -8,7 +8,8 @@ import pandas as pd
 class IIIfJsonSource(intake.source.base.DataSource):
     container = "dataframe"
     name = "iiif_json"
-    version = "0.0.1"
+    version = "0.0.2"
+    partition_access = True
 
     def __init__(self, collection_url, dtype=None, metadata=None):
         super(IIIfJsonSource, self).__init__(metadata=metadata)
@@ -22,7 +23,7 @@ class IIIfJsonSource(intake.source.base.DataSource):
         for manifest in collection_result.json().get("manifests", []):
             self._manifest_urls.append(manifest.get("@id"))
 
-    def _open_manifest(self, manifest_url):
+    def _open_manifest(self, manifest_url: str):
         manifest_result = requests.get(manifest_url)
         manifest_detail = manifest_result.json()
         record = self._construct_fields(manifest_detail)
@@ -30,7 +31,7 @@ class IIIfJsonSource(intake.source.base.DataSource):
         record.update(self._from_metadata(manifest_detail.get("metadata", [])))
         return record
 
-    def _construct_fields(self, manifest):
+    def _construct_fields(self, manifest: dict) -> dict:
         output = {}
         for name, info in self.metadata.get("fields").items():
             expression = self._path_expressions.get(name)
@@ -45,15 +46,29 @@ class IIIfJsonSource(intake.source.base.DataSource):
                 output[name] = result[0]  # Use first value
         return output
 
-    def _from_metadata(self, metadata):
+    def _from_metadata(self, metadata) -> dict:
         output = {}
         for row in metadata:
-            name = row.get('label').replace(" ", "-").lower().replace("(", "").replace(")", "")
+            name = (
+                row.get("label")
+                .replace(" ", "-")
+                .lower()
+                .replace("(", "")
+                .replace(")", "")
+            )
             if name in output:
-                output[name].append(row.get('value'))
+                output[name].append(row.get("value"))
             else:
-                output[name] = [row.get('value')]
+                output[name] = [row.get("value")]
         return output
+
+    def _get_partition(self, i) -> pd.DataFrame:
+        result = self._open_manifest(self._manifest_urls[i])
+        return pd.DataFrame(
+            [
+                result,
+            ]
+        )
 
     def _get_schema(self):
         for name, info in self.metadata.get("fields", {}).items():
@@ -69,4 +84,4 @@ class IIIfJsonSource(intake.source.base.DataSource):
 
     def read(self):
         self._load_metadata()
-        return pd.DataFrame([self._open_manifest(url) for url in self._manifest_urls])
+        return pd.concat([self.read_partition(i) for i in range(self.npartitions)])


### PR DESCRIPTION
Adds `_get_partition` method to fix this log error (adds some missing type hints as well):

```
[2021-08-27 17:22:43,146] {source_harvester.py:41} INFO - Starting harvest of bodleian
[2021-08-27 17:22:43,155] {taskinstance.py:1501} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1157, in _run_raw_task
    self._prepare_and_execute_task_with_callbacks(context, task)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1331, in _prepare_and_execute_task_with_callbacks
    result = self._execute_task(context, task_copy)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1361, in _execute_task
    result = task_copy.execute(context=context)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 150, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 161, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/opt/dlme_airflow/harvester/source_harvester.py", line 43, in data_source_harvester
    source_df = source.read()
  File "/home/airflow/.local/lib/python3.8/site-packages/intake/source/base.py", line 308, in read
    return self._get_partition(0)
  File "/home/airflow/.local/lib/python3.8/site-packages/intake/source/base.py", line 227, in _get_partition
    raise NotImplementedError
NotImplementedError
[2021-08-27 17:22:43,158] {taskinstance.py:1544} INFO - Marking task as UP_FOR_RETRY. dag_id=bodleian_iiif_harvester, task_id=bodleian_harvester, execution_date=20210827T171834, start_date=20210827T172243, end_date=20210827T172243
[2021-08-27 17:22:43,194] {local_task_job.py:149} INFO - Task exited with return code 1```