### PR TITLE
Mount DAGS and catalogs to avoid building during development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,4 @@ RUN apt-get -y update && apt-get -y install git
 USER airflow
 
 COPY --chown=airflow:root ./dlme_airflow /opt/dlme_airflow
-COPY --chown=airflow:root catalog.yaml /opt/airflow/catalog.yaml
-COPY --chown=airflow:root ./catalogs /opt/airflow/catalogs
+COPY --chown=airflow:root ./catalogs /opt/catalogs

--- a/catalogs/catalog.yaml
+++ b/catalogs/catalog.yaml
@@ -61,13 +61,13 @@ sources:
         - 'http://numismatics.org/search/query.csv?q=imagesavailable:true%20AND%20department_facet:%22Islamic%22&start=7001'
   auc_iiif:
     args:
-      path: catalogs/auc_iiif.yaml
+      path: /opt/catalogs/auc_iiif.yaml
     description: "American University in Cairo IIIf Collections"
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}
   bodleian:
     args:
-      path: catalogs/bodleian.yaml
+      path: /opt/catalogs/bodleian.yaml
     description: "Bodleian Libraries, University of Oxford"
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}

--- a/dlme_airflow/harvester/source_harvester.py
+++ b/dlme_airflow/harvester/source_harvester.py
@@ -1,6 +1,7 @@
 import logging
 import pathlib
 import time
+import os
 
 import intake
 import pandas as pd
@@ -8,7 +9,10 @@ import pandas as pd
 
 from harvester.validations import check_equality
 
-catalog = intake.open_catalog("catalog.yaml")
+
+def catalog():
+    catalog_file = os.getenv("CATALOG_SOURCE", "catalogs/catalog.yaml")
+    return intake.open_catalog(catalog_file)
 
 
 def get_existing_df(driver: str, existing_dir: pathlib.Path) -> pd.DataFrame:
@@ -39,7 +43,7 @@ def data_source_harvester(provider: str):
     @param -- provider
     """
     logging.info(f"Starting harvest of {provider}")
-    source = getattr(catalog, provider)  # Raises Attribute error for missing provider
+    source = getattr(catalog(), provider)  # Raises Attribute error for missing provider
     source_df = source.read()
     existing_directory = pathlib.Path(source.metadata.get("current_directory"))
     existing_df = get_existing_df(source._entry._driver, existing_directory)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,12 +59,14 @@ x-airflow-common:
     AIRFLOW_VAR_DATA_MANAGER_EMAIL: 'amcollie@stanford.edu'
     AIRFLOW_VAR_GIT_BRANCH: 'main'
     AIRFLOW_VAR_GIT_REPO_METADATA: 'https://github.com/sul-dlss/dlme-metadata.git'
+    CATALOG_SOURCE: '/opt/catalogs/catalogs.yml'
     _PIP_ADDITIONAL_REQUIREMENTS: 'lxml sickle intake aiohttp jsonpath_ng' # ${_PIP_ADDITIONAL_REQUIREMENTS:-}
     PYTHONPATH: '$PYTHONPATH:/opt/dlme_airflow'
   volumes:
     - ./logs:/opt/airflow/logs
-    # - ./dags:/opt/airflow/dags
-    # - ./plugins:/opt/airflow/plugins
+    - ./working:/opt/airflow/working
+    - ./dlme_airflow:/opt/dlme_airflow
+    - ./catalogs:/opt/catalogs
   user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}"
   depends_on:
     redis:


### PR DESCRIPTION
This is a small change to docker-compose to allow for reloading of the dags and harvest code without rebuilding the container and restarting docker compose.