### PR TITLE
Add Generic XML Intake driver and setup AIMS as first xml based provider

### DIFF
--- a/catalogs/catalog.yaml
+++ b/catalogs/catalog.yaml
@@ -1,6 +1,53 @@
 metadata:
   version: 1
 sources:
+  aims:
+    description: "AIMS"
+    driver: xml
+    metadata:
+      current_metadata: "/opt/airflow/metadata/aims"
+      working_directory: "/opt/airflow/working/aims/data.csv"
+      record_selector:
+        path: "//item"
+        namespace:
+      fields:
+        id:
+          path: ".//guid"
+          namespace:
+          optional: false
+        title:
+          path: ".//title"
+          namespace:
+          optional: true
+        author:
+          path: ".//itunes:author"
+          namespace:
+            itunes: "http://www.itunes.com/dtds/podcast-1.0.dtd"
+          optional: true
+        pub_date:
+          path: ".//pubDate"
+          namespace:
+          optional: true
+        description:
+          path: ".//description"
+          namespace:
+          optional: true
+        extent:
+          path: ".//itunes:duration"
+          namespace:
+            itunes: "http://www.itunes.com/dtds/podcast-1.0.dtd"
+          optional: true
+        link:
+          path: ".//link"
+          namespace:
+          optional: true
+        thumbnail:
+          path: ".//media:content/@url"
+          namespace:
+            media: "http://search.yahoo.com/mrss/"
+          optional: true
+    args:
+      collection_url: https://feed.podbean.com/themaghribpodcast/feed.xml      
   aub:
     args:
       path: /opt/catalogs/aub.yaml

--- a/dlme_airflow/dags/harvest_catalog.py
+++ b/dlme_airflow/dags/harvest_catalog.py
@@ -7,11 +7,13 @@ from airflow.models import Variable
 
 from drivers.iiif_json import IIIfJsonSource
 from drivers.oai_xml import OAIXmlSource
+from drivers.xml import XmlSource
 from utils.catalog import fetch_catalog
 from services.harvest_dag_generator import create_dag
 
 intake.source.register_driver("iiif_json", IIIfJsonSource)
 intake.source.register_driver("oai_xml", OAIXmlSource)
+intake.source.register_driver("xml", XmlSource)
 
 # These args will get passed on to each operator
 # You can override them on a per-task basis during operator initialization

--- a/dlme_airflow/drivers/xml.py
+++ b/dlme_airflow/drivers/xml.py
@@ -1,0 +1,74 @@
+import intake
+import logging
+from intake.utils import encode_datetime
+import pandas as pd
+import requests
+from lxml import etree
+
+
+class XmlSource(intake.source.base.DataSource):
+    container = "dataframe"
+    name = "xml"
+    version = "0.0.1"
+    partition_access = True
+
+    def __init__(self, collection_url, dtype=None, metadata=None):
+        super(XmlSource, self).__init__(metadata=metadata)
+        self.collection_url = collection_url
+        self._path_expressions = self._get_path_expressions()
+        self._records = []
+
+    def _open_collection(self):
+        collection_result = requests.get(self.collection_url).content
+        xtree = etree.fromstring(collection_result)
+        for counter, element in enumerate(xtree.findall(".//item"), start=1):
+            record = self._construct_fields(element)
+            self._records.append(record)
+
+    def _construct_fields(self, manifest: etree) -> dict:
+        output = {}
+        for field in self._path_expressions:
+            path = self._path_expressions[field]['path']
+            namespace = self._path_expressions[field]['namespace']
+            optional = self._path_expressions[field]['optional']
+            result = manifest.xpath(path, namespaces=namespace)
+            if len(result) < 1:
+                if optional is True:
+                    # Skip and continue
+                    continue
+                else:
+                    logging.warn(f"Manifest missing {field}")
+            else:
+                try:
+                    output[field] = self.sanitize_value(result[0].text)  # Use first value
+                except AttributeError:
+                    output[field] = self.sanitize_value(result[0]) # if getting text fails, we may be pulling an attribute. 
+        return output
+
+    def sanitize_value(self, value):
+        return value.strip().replace('\n', ' ').replace('\r', '')
+
+    def _get_partition(self, i) -> pd.DataFrame:
+        return pd.DataFrame(self._records)
+
+    def _get_path_expressions(self):
+        paths = {}
+        for name, info in self.metadata.get("fields", {}).items():
+            paths[name] = info
+
+        return paths
+
+    def _get_schema(self):
+        self._open_collection()
+
+        return intake.source.base.Schema(
+            datashape=None,
+            dtype=self.dtype,
+            shape=None,
+            npartitions=len(self._records),
+            extra_metadata={},
+        )
+
+    def read(self):
+        self._load_metadata()
+        return pd.concat([self.read_partition(i) for i in range(self.npartitions)])

--- a/dlme_airflow/drivers/xml.py
+++ b/dlme_airflow/drivers/xml.py
@@ -3,6 +3,8 @@ import logging
 import pandas as pd
 import requests
 from lxml import etree
+from lxml.html import document_fromstring
+from lxml.html.clean import Cleaner
 
 
 class XmlSource(intake.source.base.DataSource):
@@ -39,7 +41,9 @@ class XmlSource(intake.source.base.DataSource):
                     logging.warn(f"Manifest missing {field}")
             else:
                 try:
-                    output[field] = self.sanitize_value(result[0].text)  # Use first value
+                    field_doc = document_fromstring(result[0].text)
+                    cleaner = Cleaner(remove_unknown_tags=False, page_structure=True)
+                    output[field] = self.sanitize_value(cleaner.clean_html(field_doc).text_content())  # Use first value
                 except AttributeError:
                     output[field] = self.sanitize_value(result[0])  # if getting text fails, we may be pulling an attribute.
         return output

--- a/dlme_airflow/drivers/xml.py
+++ b/dlme_airflow/drivers/xml.py
@@ -1,6 +1,5 @@
 import intake
 import logging
-from intake.utils import encode_datetime
 import pandas as pd
 import requests
 from lxml import etree
@@ -42,7 +41,7 @@ class XmlSource(intake.source.base.DataSource):
                 try:
                     output[field] = self.sanitize_value(result[0].text)  # Use first value
                 except AttributeError:
-                    output[field] = self.sanitize_value(result[0]) # if getting text fails, we may be pulling an attribute. 
+                    output[field] = self.sanitize_value(result[0])  # if getting text fails, we may be pulling an attribute.
         return output
 
     def sanitize_value(self, value):


### PR DESCRIPTION
This adds a generic and configurable xml driver and the AIMS collection as a patter for configuring XML based collections.

Output can be viewed here: https://github.com/sul-dlss/dlme-metadata/blob/intake/aims/data.csv/data.csv