### PR TITLE
Refactor to use data_path (with a default) to avoid errors in the catalog config.

### DIFF
--- a/catalogs/aub.yaml
+++ b/catalogs/aub.yaml
@@ -7,8 +7,6 @@ sources:
       collection_url: https://libraries.aub.edu.lb/xtf/oai
       set: "aco"
     metadata:
-      current_metadata: "/opt/airflow/metadata/aub/aco/data.csv"
-      working_directory: "/opt/airflow/working/aub/aco"
       fields:
         id:
           path: "//header:identifier"
@@ -21,8 +19,6 @@ sources:
       collection_url: https://libraries.aub.edu.lb/xtf/oai
       set: "aladab"
     metadata:
-      current_metadata: "/opt/airflow/metadata/aub/aladab/data.csv"
-      working_directory: "/opt/airflow/working/aub/aladab"
       fields:
         id:
           path: "//header:identifier"
@@ -35,8 +31,6 @@ sources:
       collection_url: https://libraries.aub.edu.lb/xtf/oai
       set: "postcards"
     metadata:
-      current_metadata: "/opt/airflow/metadata/aub/postcards/data.csv"
-      working_directory: "/opt/airflow/working/aub/postcards"
       fields:
         id:
           path: "//header:identifier"
@@ -49,8 +43,6 @@ sources:
       collection_url: https://libraries.aub.edu.lb/xtf/oai
       set: "posters"
     metadata:
-      current_metadata: "/opt/airflow/metadata/aub/posters/data.csv"
-      working_directory: "/opt/airflow/working/aub/posters"
       fields:
         id:
           path: "//header:identifier"
@@ -63,8 +55,6 @@ sources:
       collection_url: https://libraries.aub.edu.lb/xtf/oai
       set: "travelbooks"
     metadata:
-      current_metadata: "/opt/airflow/metadata/aub/travelbooks/data.csv"
-      working_directory: "/opt/airflow/working/aub/travelbooks"
       fields:
         id:
           path: "//header:identifier"

--- a/catalogs/auc_iiif.yaml
+++ b/catalogs/auc_iiif.yaml
@@ -5,8 +5,6 @@ sources:
     description: "Al-Musawwar Magazine Collection"
     driver: iiif_json
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/al-musawwar/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/al-musawwar"
       fields:
         context:
           path: '@context'
@@ -79,8 +77,6 @@ sources:
         subject-tgm: object
         original-identifier: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/alexandria-bombardment/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/alexandria-bombardment"
       fields:
         context:
           path: '@context'
@@ -127,8 +123,6 @@ sources:
         type: object
         repository: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/bint-al-nil/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/bint-al-nil"
       fields:
         context:
           path: '@context'
@@ -178,8 +172,6 @@ sources:
         type: object
         repository: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/campus-photos/data.csv"
-      working_directory: "/opt/airflow/working/auc/campus-photos"
       fields:
         context:
           path: '@context'
@@ -233,8 +225,6 @@ sources:
         repository: object
         location: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/coptic/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/coptic"
       fields:
         context:
           path: '@context'
@@ -280,8 +270,6 @@ sources:
         location-in-arabic: object
         original-identifier: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/fathy/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/fathy"
       fields:
         context:
           path: '@context'
@@ -326,8 +314,6 @@ sources:
         type: object
         repository: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/hopkins/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/hopkins"
       fields:
         context:
           path: '@context'
@@ -375,8 +361,6 @@ sources:
         identifier: object
         description: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/islamic-aa/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/islamic-aa"
       fields:
         context:
           path: '@context'
@@ -426,8 +410,6 @@ sources:
         coverage-spatial: object
         format: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/maps/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/maps"
       fields:
         context:
           path: '@context'
@@ -477,8 +459,6 @@ sources:
         type: object
         repository: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/maritz/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/maritz"
       fields:
         context:
           path: '@context'
@@ -527,8 +507,6 @@ sources:
         format: object
         type: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/napoleonic-egypt/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/napoleonic-egypt"
       fields:
         context:
           path: '@context'
@@ -574,8 +552,6 @@ sources:
         type: object
         repository: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/parker/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/parker"
       fields:
         context:
           path: '@context'
@@ -621,8 +597,6 @@ sources:
         repository: object
         publisher: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/postcards/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/postcards"
       fields:
         context:
           path: '@context'
@@ -668,8 +642,6 @@ sources:
         identifier: object
         publisher: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/qurna/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/qurna"
       fields:
         context:
           path: '@context'
@@ -719,8 +691,6 @@ sources:
         description: object
         extent: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/rare-books/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/rare-books"
       fields:
         context:
           path: '@context'
@@ -765,8 +735,6 @@ sources:
         type: object
         repository: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/sphinx/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/sphinx"
       fields:
         context:
           path: '@context'
@@ -816,8 +784,6 @@ sources:
         name: object
         creator: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/taxiphote-slides/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/taxiphote-slides"
       fields:
         context:
           path: '@context'
@@ -871,8 +837,6 @@ sources:
         architectural-detail: object
         name: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/underwood/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/underwood"
       fields:
         context:
           path: '@context'
@@ -932,8 +896,6 @@ sources:
         occupation: object
         relationship-to-auc: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/university-on-the-square/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/university-on-the-square"
       fields:
         context:
           path: '@context'
@@ -981,8 +943,6 @@ sources:
         format: object
         original-identifier: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/auc/iiif/wassef/data.csv"
-      working_directory: "/opt/airflow/working/auc/iiif/wassef"
       fields:
         context:
           path: '@context'

--- a/catalogs/bodleian.yaml
+++ b/catalogs/bodleian.yaml
@@ -44,8 +44,6 @@ sources:
         catalogue-identifier: object
         contents: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/bodleian/arabic/data.csv"
-      working_directory: "/opt/airflow/working/bodleian/arabic"
       fields:
         id:
           path: "@id"
@@ -76,8 +74,6 @@ sources:
         record-created: object
         holding-institution: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/bodleian/exploring-egypt/data.csv"
-      working_directory: "/opt/airflow/working/bodleian/exploring-egypt"
       fields:
         id:
           path: "@id"
@@ -137,8 +133,6 @@ sources:
         acknowledgements: object
         digitization-sponsor: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/bodleian/hebrew/data.csv"
-      working_directory: "/opt/airflow/working/bodleian/hebrew"
       fields:
         id:
           path: "@id"
@@ -188,8 +182,6 @@ sources:
         related-items: object
         editors: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/bodleian/persian/data.csv"
-      working_directory: "/opt/airflow/working/bodleian/persian"
       fields:
         id:
           path: "@id"
@@ -234,8 +226,6 @@ sources:
         provenance: object
         contents: object
     metadata:
-      current_metadata: "/opt/airflow/metadata/bodleian/turkish/data.csv"
-      working_directory: "/opt/airflow/working/bodleian/turkish"
       fields:
         id:
           path: "@id"

--- a/catalogs/catalog.yaml
+++ b/catalogs/catalog.yaml
@@ -8,8 +8,6 @@ sources:
       agg_is_shown_at: True
       agg_preview: False
     metadata:
-      current_metadata: "/opt/airflow/metadata/aims"
-      working_directory: "/opt/airflow/working/aims/data.csv"
       record_selector:
         path: "//item"
         namespace:

--- a/catalogs/catalog.yaml
+++ b/catalogs/catalog.yaml
@@ -52,9 +52,7 @@ sources:
   ans:
     description: American Numismatic Society
     driver: csv
-    metadata:
-      current_metadata: /opt/airflow/metadata/american-numismatic-society/data/american-numismatic-society.csv
-      working_directory: /opt/airflow/working/american-numismatic-society
+    metadata: {}
     args:
       csv_kwargs:
         blocksize: null
@@ -113,7 +111,7 @@ sources:
     description: "American University of Beirut"
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}
-  auc_iiif:
+  auc:
     args:
       path: /opt/catalogs/auc_iiif.yaml
     description: "American University in Cairo IIIf Collections"
@@ -125,7 +123,7 @@ sources:
     description: "Bodleian Libraries, University of Oxford"
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}
-  penn_museum:
+  penn:
     args:
       path: /opt/catalogs/penn_museum.yaml
     description: Penn Museum
@@ -135,8 +133,7 @@ sources:
     description: Yale Babylonian Collection
     driver: csv
     metadata:
-      current_metadata: "/opt/airflow/metadata/yale/babylonian/data/data.csv"
-      working_directory: "/opt/airflow/working/yale/babylonian"
+      data_path: 'yale/babylonian'
       post_harvest: "/opt/dlme_airflow/utils/yale_babylon_remove_non_relevant_records.py"
     args:
       csv_kwargs:

--- a/catalogs/penn_museum.yaml
+++ b/catalogs/penn_museum.yaml
@@ -4,9 +4,7 @@ sources:
   penn_egyptian:
     description: University of Pennsylvania Egyptian Museum
     driver: csv
-    metadata:
-      current_metadata: /opt/airflow/metadata/penn/egyptian-museum/data/data.csv
-      working_directory: /opt/airflow/working/penn/egyptian-museum/data.csv
+    metadata: {}
     args:
       urlpath:
         - http://www.penn.museum/collections/assets/data/egyptian-csv-latest.zip
@@ -42,9 +40,7 @@ sources:
   penn_near_eastern:
     description: University of Pennsylvania Near Eastern Museum
     driver: csv
-    metadata:
-      current_metadata: /opt/airflow/metadata/penn/near-eastern-museum/data/data.csv
-      working_directory: /opt/airflow/working/penn/near-eastern-museum/data.csv
+    metadata: {}
     args:
       urlpath:
         - http://www.penn.museum/collections/assets/data/near-eastern-csv-latest.zip

--- a/dlme_airflow/harvester/source_harvester.py
+++ b/dlme_airflow/harvester/source_harvester.py
@@ -35,4 +35,4 @@ def data_source_harvester(**kwargs):
         for collection in has_sources:
             data_source_harvester(provider=source_provider, collection=collection)
     except TypeError:
-        dataframe_to_file(source)
+        dataframe_to_file(source, source_provider)

--- a/dlme_airflow/tasks/check_equality.py
+++ b/dlme_airflow/tasks/check_equality.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from utils.dataframe import dataframe_from_file
 from utils.catalog import catalog_for_provider

--- a/dlme_airflow/tasks/check_equality.py
+++ b/dlme_airflow/tasks/check_equality.py
@@ -1,12 +1,18 @@
+import logging
+import os
 from utils.dataframe import dataframe_from_file
 from utils.catalog import catalog_for_provider
 
 
 def check_equity(provider):
     source = catalog_for_provider(provider)
-    working_csv = f"{source.metadata.get('working_directory')}/data.csv"
+    root_dir = os.path.dirname(os.path.abspath('metadata'))
+    data_path = source.metadata.get('data_path', provider)
 
+    working_csv = os.path.join(root_dir, 'working', data_path, 'data.csv')
     working_df = dataframe_from_file('csv', working_csv)
-    current_df = dataframe_from_file('csv', source.metadata.get("current_metadata"))
+
+    current_metadata = os.path.join(root_dir, 'metadata', data_path, 'data.csv')
+    current_df = dataframe_from_file('csv', current_metadata)
 
     return current_df.equals(working_df)  # We are returning the result of this check to auto-store in a xcom variable

--- a/dlme_airflow/utils/dataframe.py
+++ b/dlme_airflow/utils/dataframe.py
@@ -19,9 +19,13 @@ def dataframe_from_file(driver: str, data_file_path: str) -> pd.DataFrame:
 
 # TODO: An Error is thrown on line 22 if working_directory is not found in
 #       the metadata. Need to handle this error.
-def dataframe_to_file(dataframe):
-    working_directory = dataframe.metadata.get("working_directory")
+def dataframe_to_file(dataframe, provider):
+    root_dir = os.path.dirname(os.path.abspath('metadata'))
+    data_path = dataframe.metadata.get('data_path', provider)
+
+    working_csv = os.path.join(root_dir, 'working', data_path, 'data.csv')
+    working_directory = os.path.join(root_dir, 'working', data_path)
     os.makedirs(working_directory, exist_ok=True)
 
     source_df = dataframe.read()
-    source_df.to_csv(f"{working_directory}/data.csv", index=False)
+    source_df.to_csv(working_csv, index=False)

--- a/dlme_airflow/utils/yale_babylon_remove_non_relevant_records.py
+++ b/dlme_airflow/utils/yale_babylon_remove_non_relevant_records.py
@@ -1,6 +1,8 @@
 # /bin/python
+import os
 import pandas as pd
-import yaml
+
+from dlme_airflow.utils.catalog import catalog_for_provider
 
 # Objects from these countries will be suppressed
 NON_RELEVANT_COUNTRIES = ['Canada',
@@ -18,13 +20,14 @@ NON_RELEVANT_COUNTRIES = ['Canada',
                           'USA']
 
 # Fetch working directory path from catalog and read file into Pandas dataframe
-with open('../catalogs/catalog.yaml', 'r') as stream:
-    catalog = yaml.safe_load(stream)
-    path = catalog['sources']['yale_babylonian']['metadata']['working_directory']
+catalog = catalog_for_provider('yale_babylonian')
+root_dir = os.path.dirname(os.path.abspath('metadata'))
+data_path = catalog.metadata.get('data_path', 'yale_babylonian')
+working_csv = os.path.join(root_dir, 'working', data_path, 'data.csv')
 
-df = pd.read_csv(f"{path}/data.csv")
+df = pd.read_csv(working_csv)
 
 # Filter out non relevant records and over write the csv
 df = df[~df['geographic_country'].isin(NON_RELEVANT_COUNTRIES)]
 
-df.to_csv(f"{path}/data.csv")
+df.to_csv(working_csv)


### PR DESCRIPTION
This addresses inconsistencies when configuring the existing and working metadata paths in the catalog.yaml configuration.