### PR TITLE
Establish a pattern for dynamic post harvest scripts

### DIFF
--- a/catalogs/ifpo.yaml
+++ b/catalogs/ifpo.yaml
@@ -3,12 +3,12 @@ metadata:
 sources:
   photographs:
     driver: oai_xml
-    post_harvest: "/opt/dlme_airflow/utils/ifpo_get_thumbnail_urls.py"
     args:
       collection_url: https://api.archives-ouvertes.fr/oai/hal
       set: "collection:IFPOIMAGES"
     metadata:
       data_path: ifpo/photographs
+      post_harvest: "add_thumbnail_urls"
       config: ifpo_config
       fields:
         id:

--- a/dlme_airflow/task_groups/etl.py
+++ b/dlme_airflow/task_groups/etl.py
@@ -19,13 +19,15 @@ from task_groups.validate_dlme_metadata import build_sync_metadata_taskgroup
 def etl_tasks(provider, task_group: TaskGroup, dag: DAG) -> TaskGroup:
     task_array = []
     source = catalog_for_provider(provider)
+    post_harvest = "add_thumbnail_urls"  # source.metadata.get('post_harvest', None)
+    logging.info(f"POST HARVEST={post_harvest}")
     logging.info(f'The source is {source}')
     try:
         collections = iter(list(source))
         for collection in collections:
-            task_array.append(build_collection_etl_taskgroup(provider, collection, "/opt/dlme_airflow/utils/ifpo_get_thumbnail_urls.py", task_group, dag))
+            task_array.append(build_collection_etl_taskgroup(provider, collection, post_harvest, task_group, dag))
     except TypeError:
-        return build_collection_etl_taskgroup(provider, None, "/opt/dlme_airflow/utils/ifpo_get_thumbnail_urls.py", task_group, dag)
+        return build_collection_etl_taskgroup(provider, None, post_harvest, task_group, dag)
 
     return task_array
 

--- a/dlme_airflow/tasks/post_harvest.py
+++ b/dlme_airflow/tasks/post_harvest.py
@@ -1,3 +1,5 @@
+import logging
+
 # The DAG object; we'll need this to instantiate a DAG
 from airflow import DAG
 
@@ -6,33 +8,27 @@ from airflow.operators.python import PythonOperator
 from airflow.utils.task_group import TaskGroup
 
 from utils.catalog import catalog_for_provider
-from utils.ifpo_get_thumbnail_urls import add_thumbnail_urls
+from utils.ifpo_get_thumbnail_urls import add_thumbnail_urls  # The method name/include must match the value in metadata.post_harvest from the catalog
 from harvester.source_post_harvester import data_source_post_harvester
 
-def run_post_harvest(**kwargs)
+def run_post_harvest(**kwargs):
   post_harvest_func = globals()[kwargs["post_harvest"]]
-
-  post_harvest_func(kwargs)  # This dynamically calls the function defined on 13 from config.
+  
+  post_harvest_func(**kwargs)  # This dynamically calls the function defined by metadata.post_harvest in the catalog
 
 
 def build_post_havest_task(provider, collection, post_harvest, task_group: TaskGroup, dag: DAG):
     if collection:
         label = f"{provider}_{collection}"
-        if post_harvest:
-            args = {"provider": provider, "collection": collection, "post_harvest": post_harvest}
-        else:
-            args = {"provider": provider, "collection": collection, post_harvest: None}
+        args = {"provider": provider, "collection": collection, "post_harvest": post_harvest}
     else:
         label = f"{provider}"
-        if post_harvest:
-            args = {"provider": provider, "collection": None, "post_harvest": post_harvest}
-        else:
-            args = {"provider": provider, "collection": None, post_harvest: None}
+        args = {"provider": provider, "collection": None, "post_harvest": post_harvest}
 
     return PythonOperator(
         task_id=f"{label}_post_harvest",
         task_group=task_group,
         dag=dag,
-        python_callable=run_post_harvest,  #  data_source_post_harvester,
+        python_callable=run_post_harvest,
         op_kwargs=args
     )

--- a/dlme_airflow/tasks/post_harvest.py
+++ b/dlme_airflow/tasks/post_harvest.py
@@ -6,20 +6,26 @@ from airflow.operators.python import PythonOperator
 from airflow.utils.task_group import TaskGroup
 
 from utils.catalog import catalog_for_provider
+from utils.ifpo_get_thumbnail_urls import add_thumbnail_urls
 from harvester.source_post_harvester import data_source_post_harvester
+
+def run_post_harvest(**kwargs)
+  post_harvest_func = globals()[kwargs["post_harvest"]]
+
+  post_harvest_func(kwargs)  # This dynamically calls the function defined on 13 from config.
 
 
 def build_post_havest_task(provider, collection, post_harvest, task_group: TaskGroup, dag: DAG):
     if collection:
         label = f"{provider}_{collection}"
         if post_harvest:
-            args = {"provider": provider, "collection": collection, post_harvest: "post_harvest"}
+            args = {"provider": provider, "collection": collection, "post_harvest": post_harvest}
         else:
             args = {"provider": provider, "collection": collection, post_harvest: None}
     else:
         label = f"{provider}"
         if post_harvest:
-            args = {"provider": provider, "collection": None, post_harvest: "post_harvest"}
+            args = {"provider": provider, "collection": None, "post_harvest": post_harvest}
         else:
             args = {"provider": provider, "collection": None, post_harvest: None}
 
@@ -27,6 +33,6 @@ def build_post_havest_task(provider, collection, post_harvest, task_group: TaskG
         task_id=f"{label}_post_harvest",
         task_group=task_group,
         dag=dag,
-        python_callable=data_source_post_harvester,
+        python_callable=run_post_harvest,  #  data_source_post_harvester,
         op_kwargs=args
     )

--- a/dlme_airflow/utils/ifpo_get_thumbnail_urls.py
+++ b/dlme_airflow/utils/ifpo_get_thumbnail_urls.py
@@ -11,19 +11,23 @@ def get_thumbnail_url(id):
     req = requests.get(url)
     return f"{req.url}/large"
 
-def add_thumbnail_urls():
+def add_thumbnail_urls(**kwargs):
     # Fetch working directory path from catalog and read file into Pandas dataframe
     catalog = catalog_for_provider('ifpo')
     root_dir = os.path.dirname(os.path.abspath('metadata'))
-    logging.info(f'Root directory path is {root_dir}.')
     data_path = catalog.metadata.get('data_path', 'ifpo/photographs')
-    logging.info(f'Data path is {root_dir}.')
     working_csv = os.path.join(root_dir, 'working', data_path, 'data.csv')
-
     df = pd.read_csv(working_csv)
 
-    # Build thumbnail url and use that to fetch larger image from redirect
-    df['thumbnail'] = ['test']
+    # A column can only be added to a data from of the same length, build an array
+    # for thumbnails that is the appropriate length
+    array_of_thumbnails = ['test'] * len(df.index)  # This is just an example with the value 'test'
+
+    ### DO YOUR THUMBANIL WORK HERE AGAINST THE DATAFRAME ###
+
+    # This assignment adds the array above to the dataframe with the header 'thumbnail'
+    df = df.assign(thumbnail=array_of_thumbnails) 
+
     logging.info('The idfo_get_thumbnail_urls file is running.')
     #df.apply(lambda row : get_thumbnail_url(row['id']), axis = 1)
 

--- a/dlme_airflow/utils/ifpo_get_thumbnail_urls.py
+++ b/dlme_airflow/utils/ifpo_get_thumbnail_urls.py
@@ -1,6 +1,5 @@
 # /bin/python
-import logging
-import os
+import os, requests
 import pandas as pd
 
 from utils.catalog import catalog_for_provider
@@ -8,8 +7,11 @@ from utils.catalog import catalog_for_provider
 def get_thumbnail_url(id):
     id = id.split(':')[-1]
     url = f"https://medihal.archives-ouvertes.fr/IFPOIMAGES/{id}"
-    req = requests.get(url)
-    return f"{req.url}/large"
+    try:
+        req = requests.get(url)
+        return f"{req.url}/large"
+    except:
+        logging.info(f'Unable to connect to: {url}')
 
 def add_thumbnail_urls(**kwargs):
     # Fetch working directory path from catalog and read file into Pandas dataframe
@@ -18,17 +20,5 @@ def add_thumbnail_urls(**kwargs):
     data_path = catalog.metadata.get('data_path', 'ifpo/photographs')
     working_csv = os.path.join(root_dir, 'working', data_path, 'data.csv')
     df = pd.read_csv(working_csv)
-
-    # A column can only be added to a data from of the same length, build an array
-    # for thumbnails that is the appropriate length
-    array_of_thumbnails = ['test'] * len(df.index)  # This is just an example with the value 'test'
-
-    ### DO YOUR THUMBANIL WORK HERE AGAINST THE DATAFRAME ###
-
-    # This assignment adds the array above to the dataframe with the header 'thumbnail'
-    df = df.assign(thumbnail=array_of_thumbnails) 
-
-    logging.info('The idfo_get_thumbnail_urls file is running.')
-    #df.apply(lambda row : get_thumbnail_url(row['id']), axis = 1)
-
+    df['thumbnail'] = df.apply(lambda row : get_thumbnail_url(row['id']), axis = 1)
     df.to_csv(working_csv)


### PR DESCRIPTION
@jacobthill Feel free to close this PR if you'd like to incorporate these suggestions into your branch (i.e. take this as an example or we can pair to walk through getting it running).

Essentially this moves the post_harvest config param into metadata for more reliable fetching than at the root level. Then instead of a file path to a script, it's a simple method name. That method should be included in the post_harvest_task so that `run_post_harvest` can call it from globals.

Let's chat on monday if we'd like to work on this further.