### PR TITLE
Read and Write harvest report from xcom instead of a file

### DIFF
--- a/dlme_airflow/tasks/harvest_report.py
+++ b/dlme_airflow/tasks/harvest_report.py
@@ -463,11 +463,7 @@ def main(**kwargs):  # input:, config:):
                                         )
                                     )
 
-    report_file = f"/tmp/report_{provider_id}_{collection_id}_{date.today()}.html"
-    report = open(report_file, "a")
-    report.write(doc.render())
-
-    return report_file
+    return doc.render()
 
 
 def build_harvest_report_task(provider, collection, task_group: TaskGroup, dag: DAG):


### PR DESCRIPTION
It is probable the individual tasks run on separate worker machines even within the same dag and task group. So we cannot rely on the workers local filesystem for locating a report content file. This moves the report into an xcom variable to ensure it is available regardless of where the send_harvest_report task is run.

This:

- refactors `harvest_report.py` to return the report content instead of writing to a file, this automatically writes to the content to an xcom variable.
- refactors `send_harvest_report.py` to read the xcom return value of the prior report task instead of a file.