### PR TITLE
Add source catalog to build sync metadata task group

### DIFF
--- a/dlme_airflow/task_groups/etl.py
+++ b/dlme_airflow/task_groups/etl.py
@@ -54,7 +54,7 @@ def build_collection_etl_taskgroup(
         harvest = build_havester_task(
             provider, collection, collection_etl_taskgroup, dag
         )  # Harvest
-        sync = build_sync_metadata_taskgroup(provider, collection, dag)
+        sync = build_sync_metadata_taskgroup(source, provider, collection, dag)
         transform = build_transform_task(
             provider, collection, collection, collection_etl_taskgroup, dag
         )  # Transform

--- a/dlme_airflow/task_groups/validate_dlme_metadata.py
+++ b/dlme_airflow/task_groups/validate_dlme_metadata.py
@@ -87,11 +87,13 @@ def build_validate_metadata_taskgroup(provider, dag: DAG) -> TaskGroup:
     return validate_metadata_taskgroup
 
 
-def build_sync_metadata_taskgroup(provider, collection, dag: DAG) -> TaskGroup:
+def build_sync_metadata_taskgroup(catalog, provider, collection, dag: DAG) -> TaskGroup:
     if collection:
-        data_path = f"{provider}/{collection}"
+        default_data_path = f"{provider}/{collection}"
     else:
-        data_path = provider
+        default_data_path = provider
+
+    data_path = catalog.metadata.get("data_path", default_data_path)
 
     task_group_prefix = (
         f"{provider.upper()}_ETL.{collection}_etl.sync_{collection}_metadata"


### PR DESCRIPTION
Injecting the source catalog is required to use the `data_path` configuration setting per collection when syncing metadata to s3.

Fixes #97 
Fixes #151 