### PR TITLE
Update harvest and transform tasks for proper data_path

### DIFF
--- a/dlme_airflow/task_groups/etl.py
+++ b/dlme_airflow/task_groups/etl.py
@@ -56,13 +56,13 @@ def build_collection_etl_taskgroup(
         )  # Harvest
         sync = build_sync_metadata_taskgroup(source, provider, collection, dag)
         transform = build_transform_task(
-            provider, collection, collection, collection_etl_taskgroup, dag
+            source, provider, collection, collection_etl_taskgroup, dag
         )  # Transform
         load = index_task(
             provider, collection, collection_etl_taskgroup, dag
         )  # Load / Index
         report = build_harvest_report_task(
-            provider, collection, collection_etl_taskgroup, dag
+            source, provider, collection, collection_etl_taskgroup, dag
         )  # Report
         send_report = build_send_harvest_report_task(
             provider, collection, collection_etl_taskgroup, dag

--- a/dlme_airflow/tasks/transform.py
+++ b/dlme_airflow/tasks/transform.py
@@ -8,13 +8,13 @@ from airflow.providers.amazon.aws.operators.ecs import ECSOperator
 from airflow.utils.task_group import TaskGroup
 
 
-def build_transform_task(
-    provider, collection, data_path, task_group: TaskGroup, dag: DAG
-):
+def build_transform_task(source, provider, collection, task_group: TaskGroup, dag: DAG):
     if collection:
         coll_label = f"{provider}.{collection}"
     else:
         coll_label = provider
+
+    data_path = source.metadata.get("data_path")
 
     return ECSOperator(
         task_id=f"transform_{coll_label}",


### PR DESCRIPTION
Resolves inconsistency between collection naming and the data path used for the intermediate representation from dlme-transform.

This is a precursor to refactoring the harvest report.