### PR TITLE
Fix AWS access key env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ open your browser to `http://localhost:8080`
 ### Allowing local Airflow to execute AWS resources
 
 In order to trigger `dlme-transform` or `dlme-index` while running Airflow locally via `docker compose` your
-`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `DEV_ROLE_ARN`, `ECS_SECURITY_GROUP`, `ECS_SUBNET` must be set in your local environment and a [configured aws connection](https://github.com/sul-dlss/dlme-airflow/wiki/Amazon-Web-Services-(AWS)-connection-configuration). 
+`AWS_ACCESS_KEY`, `AWS_SECRET_ACCESS_KEY`, `DEV_ROLE_ARN`, `ECS_SECURITY_GROUP`, `ECS_SUBNET` must be set in your local environment and a [configured aws connection](https://github.com/sul-dlss/dlme-airflow/wiki/Amazon-Web-Services-(AWS)-connection-configuration). 
 
 Add a `.env` file to the root directory of the project and add your AWS credentials:
 ```
-AWS_ACCESS_KEY_ID={YOUR AWS_ACCESS_KEY_ID}
+AWS_ACCESS_KEY={YOUR AWS_ACCESS_KEY}
 AWS_SECRET_ACCESS_KEY={YOUR AWS_SECRET_ACCESS_KEY}
 DEV_ROLE_ARN={The DEV_ROLE_ARN}
 ECS_SECURITY_GROUP={Get value from shared configs}


### PR DESCRIPTION
The docker-compose.yml expects to find `AWS_ACCESS_KEY` instead of `AWS_ACCESS_KEY_ID` from the `.env` file.
