### PR TITLE
SKIP_REPORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ ECS_SECURITY_GROUP={Get value from shared configs}
 ECS_SUBNET={Get value from shared configs}
 ```
 
+If you would like to be able to skip report generation and delivery in your development environment (which can be time consuming) you can add `SKIP_REPORT=true` to your `.env` as well. 
+
 # Fetching data for review from S3
 
 DLME-airlfow writes the metadata harvested from providers to S3. It is possible to fetch the written data in CSV format using the [aws cli](https://github.com/sul-dlss/terraform-aws/wiki/AWS-DLSS-Dev-Env-Setup).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,6 +66,7 @@ x-airflow-common:
     ECS_SECURITY_GROUP: "${ECS_SECURITY_GROUP}"
     ECS_SUBNET: "${ECS_SUBNET}"
     S3_BUCKET: "s3://dlme-metadata-dev/metadata"
+    SKIP_REPORT: "${SKIP_REPORT}"
   volumes:
     - ./logs:/opt/airflow/logs
     - ./working:/opt/airflow/working


### PR DESCRIPTION
If SKIP_REPORT is defined in the environment don't generate and send the report. This is for development environments that are using the `.env` file.

Closes #161
