### PR TITLE
SequentialCsvSource

### DIFF
--- a/catalogs/yale.yaml
+++ b/catalogs/yale.yaml
@@ -4,15 +4,7 @@ metadata:
 sources:
   babylonian:
     description: Yale babylonian
-    driver: csv
-    metadata:
-      data_path: yale/babylonian
-      post_harvest: "remove_non_relevant"
-      config: yale_babylon_config
-      fields:
-        id:
-          name_in_dataframe: "id"
-          path: "id"
+    driver: sequential_csv
     args:
       csv_kwargs:
         blocksize: null
@@ -63,4 +55,11 @@ sources:
         - https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=17&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv
         - https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=18&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv
         - https://collections.peabody.yale.edu/search/Search/Results?join=AND&bool0%5B%5D=AND&lookfor0%5B%5D=BC&type0%5B%5D=AllFields&limit=100&page=19&filter%5B%5D=~collection%3A%22Anthropology%22&filter%5B%5D=resource%3A%22Resource+available+online%22&view=csv
-
+      metadata:
+        data_path: yale/babylonian
+        post_harvest: "remove_non_relevant"
+        config: yale_babylon_config
+        fields:
+          id:
+            name_in_dataframe: "id"
+            path: "id"

--- a/dlme_airflow/dags/harvest_catalog.py
+++ b/dlme_airflow/dags/harvest_catalog.py
@@ -10,6 +10,7 @@ from drivers.iiif_json import IIIfJsonSource
 from drivers.feed import FeedSource
 from drivers.oai_xml import OAIXmlSource
 from drivers.xml import XmlSource
+from drivers.sequential_csv import SequentialCsvSource
 from utils.catalog import fetch_catalog
 from services.harvest_dag_generator import create_dag
 from models.provider import Provider
@@ -18,6 +19,7 @@ intake.source.register_driver("iiif_json", IIIfJsonSource)
 intake.source.register_driver("oai_xml", OAIXmlSource)
 intake.source.register_driver("feed", FeedSource)
 intake.source.register_driver("xml", XmlSource)
+intake.source.register_driver("sequential_csv", SequentialCsvSource)
 
 # These args will get passed on to each operator
 # You can override them on a per-task basis during operator initialization

--- a/dlme_airflow/drivers/sequential_csv.py
+++ b/dlme_airflow/drivers/sequential_csv.py
@@ -1,0 +1,38 @@
+import pandas
+import logging
+
+from intake.source.base import DataSource, Schema
+
+
+class SequentialCsvSource(DataSource):
+    """Loads multiple CSV files sequentially with pandas rather than in parallel
+    with dask. This can be helpful in situations where dask is aggravating the
+    web server that is publishing the CSV data with HEAD requests and things
+    that it is not able to respond to in parallel.
+    """
+
+    container = "dataframe"
+    name = "sequential-csv"
+    version = "0.0.1"
+    partition_access = True
+
+    def __init__(self, urlpath, metadata={}, csv_kwargs={}):
+        self.urls = urlpath if type(urlpath) == list else [urlpath]
+        self.csv_kwargs = csv_kwargs
+        super(SequentialCsvSource, self).__init__(metadata=metadata)
+
+    def _get_schema(self):
+        return Schema(
+            datashape=None,
+            dtype=self.csv_kwargs.get("dtype"),
+            shape=None,
+            npartitions=len(self.urls),
+        )
+
+    def _get_partition(self, i):
+        logging.info(f"reading {self.urls[i]}")
+        return pandas.read_csv(self.urls[i])
+
+    def read(self):
+        self._load_metadata()
+        return pandas.concat([self.read_partition(i) for i in range(self.npartitions)])

--- a/dlme_airflow/utils/dataframe.py
+++ b/dlme_airflow/utils/dataframe.py
@@ -5,7 +5,7 @@ import pandas as pd
 # TODO: If not files are found / dir is empty / etc, this raising an error.
 #       We should handle this error more cleanly.
 def dataframe_from_file(driver: str, data_file_path: str) -> pd.DataFrame:
-    """ "Returns existing DLME metadata as a Panda dataframe based on the
+    """Returns existing DLME metadata as a Pandas dataframe based on the
     type of driver.
 
     @param -- driver The registered DataSource name

--- a/tests/data/csv/example1.csv
+++ b/tests/data/csv/example1.csv
@@ -1,0 +1,5 @@
+id,title
+1,Example 1
+2,Example 2
+3,Example 3
+4,Example 4

--- a/tests/data/csv/example2.csv
+++ b/tests/data/csv/example2.csv
@@ -1,0 +1,5 @@
+id,title
+5,Example 5
+6,Example 6
+7,Example 7
+8,Example 8

--- a/tests/data/csv/example3.csv
+++ b/tests/data/csv/example3.csv
@@ -1,0 +1,5 @@
+id,title
+9,Example 9
+10,Example 10
+11,Example 11
+12,Example 12

--- a/tests/data/csv/example4.csv
+++ b/tests/data/csv/example4.csv
@@ -1,0 +1,5 @@
+id,title
+13,Example 13
+14,Example 14
+15,Example 15
+16,Example 16

--- a/tests/data/csv/example5.csv
+++ b/tests/data/csv/example5.csv
@@ -1,0 +1,5 @@
+id,title
+17,Example 17
+18,Example 18
+19,Example 19 
+20,Example 20

--- a/tests/drivers/test_sequential_csv.py
+++ b/tests/drivers/test_sequential_csv.py
@@ -1,0 +1,20 @@
+from dlme_airflow.drivers.sequential_csv import SequentialCsvSource
+
+
+def test_one():
+    src = SequentialCsvSource(urlpath="tests/data/csv/example1.csv")
+    df = src.read()
+    assert len(df) == 4
+
+
+def test_multi():
+    files = [
+        "tests/data/csv/example1.csv",
+        "tests/data/csv/example2.csv",
+        "tests/data/csv/example3.csv",
+        "tests/data/csv/example4.csv",
+        "tests/data/csv/example5.csv",
+    ]
+    src = SequentialCsvSource(urlpath=files)
+    df = src.read()
+    assert len(df) == 20


### PR DESCRIPTION
SequentialCsvSource loads CSVs sequentially using pandas rather than using dask which issues HEAD requests in parallel to get the content-length and see if the server supports HTTP Range requests. Since `collections.peabody.yale.edu` is dynamically generating the CSV responses it is getting 20 concurrent HEAD requests which seems to cause it to throw a 500 Internal Server Error. Loading each CSV one at a time, and merging in to a single DataFrame for further processing seems to not cause the server errors.

While this closes #152 since the harvest works I don't think the downstream transform task is working?
