### PR TITLE
Normalize abbreviations in class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ yale_babylonian:
 ```
 
 #### IIIF Catalog
-For the collections with IIIF JSON format, we created a new `IIIFJsonSource`
+For the collections with IIIF JSON format, we created a new `IiifJsonSource`
 driver class that extends `intake.source.base.DataSource`. In catalogs sources
 that use this driver, set the driver value to *iiif_json*.
 

--- a/catalogs/catalog.yaml
+++ b/catalogs/catalog.yaml
@@ -22,7 +22,7 @@ sources:
   auc:
     args:
       path: /opt/airflow/catalogs/auc.yaml
-    description: "American University in Cairo IIIf Collections"
+    description: "American University in Cairo IIIF Collections"
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}
   bodleian:

--- a/dlme_airflow/dags/harvest_catalog.py
+++ b/dlme_airflow/dags/harvest_catalog.py
@@ -6,16 +6,16 @@ from datetime import timedelta
 # Operators and utils required from airflow
 from airflow.models import Variable
 
-from drivers.iiif_json import IIIfJsonSource
+from drivers.iiif_json import IiifJsonSource
 from drivers.feed import FeedSource
-from drivers.oai_xml import OAIXmlSource
+from drivers.oai_xml import OaiXmlSource
 from drivers.xml import XmlSource
 from utils.catalog import fetch_catalog
 from services.harvest_dag_generator import create_dag
 from models.provider import Provider
 
-intake.source.register_driver("iiif_json", IIIfJsonSource)
-intake.source.register_driver("oai_xml", OAIXmlSource)
+intake.source.register_driver("iiif_json", IiifJsonSource)
+intake.source.register_driver("oai_xml", OaiXmlSource)
 intake.source.register_driver("feed", FeedSource)
 intake.source.register_driver("xml", XmlSource)
 

--- a/dlme_airflow/drivers/iiif_json.py
+++ b/dlme_airflow/drivers/iiif_json.py
@@ -10,9 +10,9 @@ version = "0.0.2"
 partition_access = True
 
 
-class IIIfJsonSource(intake.source.base.DataSource):
+class IiifJsonSource(intake.source.base.DataSource):
     def __init__(self, collection_url, dtype=None, metadata=None):
-        super(IIIfJsonSource, self).__init__(metadata=metadata)
+        super(IiifJsonSource, self).__init__(metadata=metadata)
         self.collection_url = collection_url
         self.dtype = dtype
         self._manifest_urls = []
@@ -27,7 +27,7 @@ class IIIfJsonSource(intake.source.base.DataSource):
         manifest_result = requests.get(manifest_url)
         manifest_detail = manifest_result.json()
         record = self._construct_fields(manifest_detail)
-        # Handles metadata in IIIf manfest
+        # Handles metadata in IIIF manfest
         record.update(self._from_metadata(manifest_detail.get("metadata", [])))
         return record
 

--- a/dlme_airflow/drivers/oai_xml.py
+++ b/dlme_airflow/drivers/oai_xml.py
@@ -5,7 +5,7 @@ from sickle import Sickle
 from lxml import etree
 
 
-class OAIXmlSource(intake.source.base.DataSource):
+class OaiXmlSource(intake.source.base.DataSource):
     container = "dataframe"
     name = "oai_xml"
     version = "0.0.1"
@@ -14,7 +14,7 @@ class OAIXmlSource(intake.source.base.DataSource):
     def __init__(
         self, collection_url, metadata_prefix, set=None, dtype=None, metadata=None
     ):
-        super(OAIXmlSource, self).__init__(metadata=metadata)
+        super(OaiXmlSource, self).__init__(metadata=metadata)
         self.collection_url = collection_url
         self.metadata_prefix = metadata_prefix
         self.set = set

--- a/tests/drivers/test_iiif_json.py
+++ b/tests/drivers/test_iiif_json.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 import pandas as pd
 
-from dlme_airflow.drivers.iiif_json import IIIfJsonSource
+from dlme_airflow.drivers.iiif_json import IiifJsonSource
 
 
 class MockIIIFCollectionResponse:
@@ -54,16 +54,16 @@ def iiif_test_source():
             "iiif_format": {"path": "sequences..format"},
         }
     }
-    return IIIfJsonSource(
+    return IiifJsonSource(
         collection_url="http://iiif_collection.json", metadata=metadata
     )
 
 
-def test_IIIfJsonSource_initial(iiif_test_source, mock_response):
+def test_IiifJsonSource_initial(iiif_test_source, mock_response):
     assert len(iiif_test_source._manifest_urls) == 0
 
 
-def test_IIIfJsonSource_get_schema(iiif_test_source, mock_response):
+def test_IiifJsonSource_get_schema(iiif_test_source, mock_response):
     iiif_test_source._get_schema()
     assert (
         iiif_test_source._manifest_urls[0]
@@ -71,13 +71,13 @@ def test_IIIfJsonSource_get_schema(iiif_test_source, mock_response):
     )
 
 
-def test_IIIfJsonSource_read(iiif_test_source, mock_response):
+def test_IiifJsonSource_read(iiif_test_source, mock_response):
     iiif_df = iiif_test_source.read()
     test_columns = ["context", "iiif_format", "source", "title-main"]
     assert all([a == b for a, b in zip(iiif_df.columns, test_columns)])
 
 
-def test_test_IIIfJsonSource_df(iiif_test_source, mock_response):
+def test_test_IiifJsonSource_df(iiif_test_source, mock_response):
     iiif_df = iiif_test_source.read()
     test_df = pd.DataFrame(
         [


### PR DESCRIPTION
The driver classes have abbreviations in them. This commit changes them to use CamelCase for consistency. So IiifJsonSource instead of IIIFJsonSource or IIIFJSONSource, and OaiXmlSource instead of OAIXmlSource.

Fixes #186
