### PR TITLE
Ensure DAGs are defined in harvest_catalog module

### DIFF
--- a/dlme_airflow/dags/harvest_catalog.py
+++ b/dlme_airflow/dags/harvest_catalog.py
@@ -1,4 +1,39 @@
-from services.harvest_dag_generator import create_provider_dags, register_drivers
+import intake
+import logging
 
-register_drivers()
-create_provider_dags()
+from datetime import timedelta
+
+from airflow.models import Variable
+
+from drivers.iiif_json import IiifJsonSource
+from drivers.feed import FeedSource
+from drivers.oai_xml import OaiXmlSource
+from drivers.xml import XmlSource
+from drivers.sequential_csv import SequentialCsvSource
+from utils.catalog import fetch_catalog
+from services.harvest_dag_generator import create_dag
+from models.provider import Provider
+
+intake.source.register_driver("iiif_json", IiifJsonSource)
+intake.source.register_driver("oai_xml", OaiXmlSource)
+intake.source.register_driver("feed", FeedSource)
+intake.source.register_driver("xml", XmlSource)
+intake.source.register_driver("sequential_csv", SequentialCsvSource)
+
+# These args will get passed on to each operator
+# You can override them on a per-task basis during operator initialization
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email": [Variable.get("data_manager_email")],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": timedelta(seconds=60),
+    "catchup": False,
+}
+
+for provider in iter(list(fetch_catalog())):
+    current_provider = Provider(provider)
+    logging.info(f"Creating DAG for {current_provider.name}")
+    globals()[provider] = create_dag(current_provider, default_args)

--- a/dlme_airflow/services/harvest_dag_generator.py
+++ b/dlme_airflow/services/harvest_dag_generator.py
@@ -1,47 +1,13 @@
 from datetime import datetime
-from datetime import timedelta
-import logging
+
+# The DAG object; we'll need this to instantiate a DAG
+from airflow import DAG
 
 # Operators and utils required from airflow
-from airflow import DAG
 from airflow.operators.dummy import DummyOperator
-from airflow.models import Variable
-
-import intake
 
 # Our stuff
-from drivers.iiif_json import IiifJsonSource
-from drivers.feed import FeedSource
-from drivers.oai_xml import OaiXmlSource
-from drivers.xml import XmlSource
-from drivers.sequential_csv import SequentialCsvSource
-from models.provider import Provider
 from task_groups.etl import build_provider_etl_taskgroup
-from utils.catalog import fetch_catalog
-
-
-_harvest_dags = dict()
-
-
-def harvest_dags():
-    return _harvest_dags
-
-
-def default_dag_args():
-    """
-    These args will get passed on to each operator.
-    You can override them on a per-task basis during operator initialization.
-    """
-    return {
-        "owner": "airflow",
-        "depends_on_past": False,
-        "email": [Variable.get("data_manager_email")],
-        "email_on_failure": False,
-        "email_on_retry": False,
-        "retries": 0,
-        "retry_delay": timedelta(seconds=60),
-        "catchup": False,
-    }
 
 
 def create_dag(provider, default_args):
@@ -74,21 +40,3 @@ def create_dag(provider, default_args):
         harvest_begin >> etl >> harvest_complete
 
     return dag
-
-
-def register_drivers():
-    intake.source.register_driver("iiif_json", IiifJsonSource)
-    intake.source.register_driver("oai_xml", OaiXmlSource)
-    intake.source.register_driver("feed", FeedSource)
-    intake.source.register_driver("xml", XmlSource)
-    intake.source.register_driver("sequential_csv", SequentialCsvSource)
-
-
-def create_provider_dags():
-    for provider in iter(list(fetch_catalog())):
-        current_provider = Provider(provider)
-        logging.info(f"Creating DAG for {current_provider.name}")
-        globals()[provider] = create_dag(current_provider, default_dag_args())
-        _harvest_dags[provider] = globals()[provider]
-
-    logging.info(f"_harvest_dags={_harvest_dags}")

--- a/tests/services/test_harvest_dag_generator.py
+++ b/tests/services/test_harvest_dag_generator.py
@@ -1,14 +1,8 @@
 import pytest
+import inspect
 
-from airflow import models
+from airflow import DAG, models
 from airflow.utils.dag_cycle_tester import check_cycle
-
-from dlme_airflow.services.harvest_dag_generator import (
-    create_provider_dags,
-    register_drivers,
-    harvest_dags,
-)
-from utils.catalog import fetch_catalog
 
 
 @pytest.fixture
@@ -21,9 +15,9 @@ def mock_variable(monkeypatch):
 
 
 def test_create_provider_dags(mock_variable):
-    register_drivers()
-    create_provider_dags()
-    assert list(harvest_dags().keys()) == list(fetch_catalog())
-    for provider in iter(list(fetch_catalog())):
-        dag = harvest_dags()[provider]
-        check_cycle(dag)
+    # import here after our mock has had a chance to take effect
+    from dags import harvest_catalog
+
+    for name, member in inspect.getmembers(harvest_catalog):
+        if isinstance(member, DAG):
+            check_cycle(member)


### PR DESCRIPTION
This commit moves `dlme_airflow.dags.harvest_catalog` and `dlme_airflow.services.harvest_dag_generator` back to their previous state and adjusts the unit test to inspect the harvest_catalog module to see what DAG classes are available.

Closes #193
