### PR TITLE
Ensure DAGs are defined in harvest_catalog module (alt)

### DIFF
--- a/dlme_airflow/dags/harvest_catalog.py
+++ b/dlme_airflow/dags/harvest_catalog.py
@@ -1,4 +1,9 @@
 from services.harvest_dag_generator import create_provider_dags, register_drivers
 
 register_drivers()
-create_provider_dags()
+
+# Believe it or not airflow will only load this file during dag discovery
+# if the file contains the words "dag" and "airflow", at least in Ariflow v2
+# https://github.com/apache/airflow/blob/3b76e81bcc9010cfec4d41fe33f92a79020dbc5b/airflow/utils/file.py#L337-L357
+
+create_provider_dags(module_name=__name__)


### PR DESCRIPTION
*This is an alternative approach to making DAGs discoverable without rolling back changes made in #195.*

---

Airflow has an amusing heuristic to determine whether a folder contains dags or not:

https://github.com/apache/airflow/blob/main/airflow/utils/file.py#L337-L357

Basically the .py file must contain the words 'airflow' and 'dag' and since dlme_airflow.dags.harvest_catalog.py no longer does it isn't loading it at all :)

The other problem is that the DAG classes are being created in the dlme_airflow.services.harvest_dag_generator module instead of dlme_airflow.dags.harvest_catalog. So even after aiflow has loaded the file it doesn't find any DAG classes in it, and so it decides there aren't any.

So this commit adds a comment with 'airflow' and 'dag' in it to dlme_airflow.dags.harvest_catalog and also adjusts create_provider_dags to take an optional module name to create the classes in.

Closes #193
