### PR TITLE
bin/get for getting provider data on the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,22 @@ exploring_egypt:
 
 ```
 
+#### Getting Data
+
+Sometimes it can be useful to be able to fetch data from a provider on the command line. This can be useful when adding or modifying a catalog entry, developing a driver, or when working with the data that is collected. To aid in that the `bin/get` utility will fetch data from a provider/collection and output the collected CSV to stdout or to a file.
+
+First you'll want to enter the poetry virtual environment:
+
+```
+$ poetry shell
+```
+
+and then run `bin/get` with a provider and collection as arguments (optionally you can write to a file with `--output`, or aboart the harvest early with `--limit`):
+
+```
+$ bin/get yale babylonian --limit 20
+```
+
 [BLK]: https://black.readthedocs.io/en/stable/index.html
 [FLK8]: https://flake8.pycqa.org/en/latest/
 [Poetry]: https://python-poetry.org

--- a/bin/get
+++ b/bin/get
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# A utility for getting a provider collection from the intake catalog, running
+# the data collection and writing the CSV to stdout or a given location.
+
+import sys
+import logging
+import argparse
+
+from signal import signal, SIGPIPE, SIG_DFL  
+from dlme_airflow.models.provider import Provider
+from dlme_airflow.drivers import register_drivers
+
+
+def main(opts):
+    register_drivers()
+    provider = Provider(opts.provider)
+    collection = provider.get_collection(opts.collection)
+    if collection is None:
+        sys.exit("No such collection {opts.collection} for provider {opts.provider}")
+
+    # set driver record limit if it is allowed by the driver
+    if opts.limit: 
+        if hasattr(collection.catalog, 'record_limit'):
+            collection.catalog.record_limit = opts.limit
+        else:
+            logging.error(f"Unable to use --limit with {type(collection.catalog).name} driver")
+    
+    # read the data
+    df = collection.catalog.read()
+
+    # send output to a file or stdout
+    out = opts.output if opts.output else sys.stdout
+    df.to_csv(out, index=False)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Get data from a DLME provider collection as CSV")
+    parser.add_argument('provider', help="The DLME provider (e.g. penn)")
+    parser.add_argument('collection', help="The provider's collection (e.g. penn_egyptian")
+    parser.add_argument("--output", help="File to write CSV output to")
+    parser.add_argument("--limit", type=int, help="Limit output to number of rows")
+    opts = parser.parse_args()
+
+    # Ignore broken pipe errors when running from the command line.
+    # This allows: bin/get penn penn_babylonian | head -10
+    signal(SIGPIPE,SIG_DFL)
+
+    main(opts)

--- a/dlme_airflow/dags/harvest_catalog.py
+++ b/dlme_airflow/dags/harvest_catalog.py
@@ -1,4 +1,5 @@
-from services.harvest_dag_generator import create_provider_dags, register_drivers
+from dlme_airflow.services.harvest_dag_generator import create_provider_dags
+from dlme_airflow.drivers import register_drivers
 
 register_drivers()
 

--- a/dlme_airflow/drivers/__init__.py
+++ b/dlme_airflow/drivers/__init__.py
@@ -1,0 +1,15 @@
+import intake
+
+from dlme_airflow.drivers.iiif_json import IiifJsonSource
+from dlme_airflow.drivers.feed import FeedSource
+from dlme_airflow.drivers.oai_xml import OaiXmlSource
+from dlme_airflow.drivers.xml import XmlSource
+from dlme_airflow.drivers.sequential_csv import SequentialCsvSource
+
+
+def register_drivers():
+    intake.source.register_driver("iiif_json", IiifJsonSource)
+    intake.source.register_driver("oai_xml", OaiXmlSource)
+    intake.source.register_driver("feed", FeedSource)
+    intake.source.register_driver("xml", XmlSource)
+    intake.source.register_driver("sequential_csv", SequentialCsvSource)

--- a/dlme_airflow/drivers/sequential_csv.py
+++ b/dlme_airflow/drivers/sequential_csv.py
@@ -17,9 +17,11 @@ class SequentialCsvSource(DataSource):
     partition_access = True
 
     def __init__(self, urlpath, metadata={}, csv_kwargs={}):
+        super(SequentialCsvSource, self).__init__(metadata=metadata)
         self.urls = urlpath if type(urlpath) == list else [urlpath]
         self.csv_kwargs = csv_kwargs
-        super(SequentialCsvSource, self).__init__(metadata=metadata)
+        self.record_limit = self.metadata.get("record_limit", None)
+        self.record_count = 0
 
     def _get_schema(self):
         return Schema(
@@ -30,9 +32,18 @@ class SequentialCsvSource(DataSource):
         )
 
     def _get_partition(self, i):
+        if self.record_limit and self.record_count > self.record_limit:
+            logging.info(f"skipping partition because record limit {self.record_limit}")
+            return pandas.DataFrame()
         logging.info(f"reading {self.urls[i]}")
-        return pandas.read_csv(self.urls[i])
+        df = pandas.read_csv(self.urls[i])
+        self.record_count += len(df)
+        return df
 
     def read(self):
         self._load_metadata()
-        return pandas.concat([self.read_partition(i) for i in range(self.npartitions)])
+        df = pandas.concat([self.read_partition(i) for i in range(self.npartitions)])
+        if self.record_limit:
+            return df.head(self.record_limit)
+        else:
+            return df

--- a/dlme_airflow/models/collection.py
+++ b/dlme_airflow/models/collection.py
@@ -1,4 +1,4 @@
-from utils.catalog import catalog_for_provider
+from dlme_airflow.utils.catalog import catalog_for_provider
 
 
 class Collection(object):

--- a/dlme_airflow/models/provider.py
+++ b/dlme_airflow/models/provider.py
@@ -1,5 +1,5 @@
-from utils.catalog import catalog_for_provider
-from models.collection import Collection
+from dlme_airflow.utils.catalog import catalog_for_provider
+from dlme_airflow.models.collection import Collection
 
 
 class Provider(object):
@@ -7,6 +7,12 @@ class Provider(object):
         self.name = catalog
         self.catalog = catalog_for_provider(catalog)
         self.collections = self.__collections_for()
+
+    def get_collection(self, collection_name):
+        for coll in self.collections:
+            if coll.name == collection_name:
+                return coll
+        return None
 
     def data_path(self):
         return self.catalog.metadata.get("data_path", self.name)

--- a/dlme_airflow/services/harvest_dag_generator.py
+++ b/dlme_airflow/services/harvest_dag_generator.py
@@ -9,17 +9,10 @@ from airflow import DAG
 from airflow.operators.dummy import DummyOperator
 from airflow.models import Variable
 
-import intake
-
 # Our stuff
-from drivers.iiif_json import IiifJsonSource
-from drivers.feed import FeedSource
-from drivers.oai_xml import OaiXmlSource
-from drivers.xml import XmlSource
-from drivers.sequential_csv import SequentialCsvSource
-from models.provider import Provider
-from task_groups.etl import build_provider_etl_taskgroup
-from utils.catalog import fetch_catalog
+from dlme_airflow.models.provider import Provider
+from dlme_airflow.task_groups.etl import build_provider_etl_taskgroup
+from dlme_airflow.utils.catalog import fetch_catalog
 
 
 _harvest_dags = dict()
@@ -76,14 +69,6 @@ def create_dag(provider, default_args):
         harvest_begin >> etl >> harvest_complete
 
     return dag
-
-
-def register_drivers():
-    intake.source.register_driver("iiif_json", IiifJsonSource)
-    intake.source.register_driver("oai_xml", OaiXmlSource)
-    intake.source.register_driver("feed", FeedSource)
-    intake.source.register_driver("xml", XmlSource)
-    intake.source.register_driver("sequential_csv", SequentialCsvSource)
 
 
 def create_provider_dags(module_name=None):

--- a/dlme_airflow/task_groups/detect_metadata_changes.py
+++ b/dlme_airflow/task_groups/detect_metadata_changes.py
@@ -5,8 +5,8 @@ from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.task_group import TaskGroup
 
-from utils.catalog import catalog_for_provider
-from tasks.check_equality import check_equity
+from dlme_airflow.utils.catalog import catalog_for_provider
+from dlme_airflow.tasks.check_equality import check_equity
 
 
 def build_detect_changes_task(provider, task_group: TaskGroup, dag: DAG):

--- a/dlme_airflow/task_groups/etl.py
+++ b/dlme_airflow/task_groups/etl.py
@@ -7,13 +7,15 @@ from airflow import DAG
 # Operators and utils required from airflow
 from airflow.utils.task_group import TaskGroup
 
-from tasks.harvest import build_harvester_task
-from tasks.post_harvest import build_post_harvest_task
-from tasks.transform import build_transform_task
-from tasks.index import index_task
-from tasks.harvest_report import build_harvest_report_task
-from tasks.send_harvest_report import build_send_harvest_report_task
-from task_groups.validate_dlme_metadata import build_sync_metadata_taskgroup
+from dlme_airflow.tasks.harvest import build_harvester_task
+from dlme_airflow.tasks.post_harvest import build_post_harvest_task
+from dlme_airflow.tasks.transform import build_transform_task
+from dlme_airflow.tasks.index import index_task
+from dlme_airflow.tasks.harvest_report import build_harvest_report_task
+from dlme_airflow.tasks.send_harvest_report import build_send_harvest_report_task
+from dlme_airflow.task_groups.validate_dlme_metadata import (
+    build_sync_metadata_taskgroup,
+)
 
 
 def etl_tasks(provider, task_group: TaskGroup, dag: DAG) -> TaskGroup:

--- a/dlme_airflow/tasks/check_equality.py
+++ b/dlme_airflow/tasks/check_equality.py
@@ -1,6 +1,6 @@
 import os
-from utils.dataframe import dataframe_from_file
-from utils.catalog import catalog_for_provider
+from dlme_airflow.utils.dataframe import dataframe_from_file
+from dlme_airflow.utils.catalog import catalog_for_provider
 
 
 def check_equity(provider):

--- a/dlme_airflow/tasks/harvest.py
+++ b/dlme_airflow/tasks/harvest.py
@@ -5,7 +5,7 @@ from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.task_group import TaskGroup
 
-from harvester.source_harvester import data_source_harvester
+from dlme_airflow.harvester.source_harvester import data_source_harvester
 
 
 def build_harvester_task(collection, task_group: TaskGroup, dag: DAG):

--- a/dlme_airflow/tasks/harvest_report.py
+++ b/dlme_airflow/tasks/harvest_report.py
@@ -11,7 +11,7 @@ from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.task_group import TaskGroup
 
-from utils.catalog import catalog_for_provider
+from dlme_airflow.utils.catalog import catalog_for_provider
 
 # Constants for crosswalk
 fields = [

--- a/dlme_airflow/tasks/post_harvest.py
+++ b/dlme_airflow/tasks/post_harvest.py
@@ -5,8 +5,10 @@ from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.task_group import TaskGroup
 
-from utils.add_thumbnails import add_thumbnails
-from utils.yale_babylon_remove_non_relevant_records import remove_non_relevant
+from dlme_airflow.utils.add_thumbnails import add_thumbnails
+from dlme_airflow.utils.yale_babylon_remove_non_relevant_records import (
+    remove_non_relevant,
+)
 
 # The method name/include must match the value in metadata.post_harvest from the catalog
 

--- a/dlme_airflow/tasks/send_harvest_report.py
+++ b/dlme_airflow/tasks/send_harvest_report.py
@@ -3,7 +3,7 @@ from airflow.operators.python import PythonOperator
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.email import send_email
 
-from utils.catalog import catalog_for_provider
+from dlme_airflow.utils.catalog import catalog_for_provider
 
 
 def email_callback(task_instance, task, **kwargs):

--- a/tests/services/test_harvest_dag_generator.py
+++ b/tests/services/test_harvest_dag_generator.py
@@ -5,10 +5,10 @@ from airflow.utils.dag_cycle_tester import check_cycle
 
 from dlme_airflow.services.harvest_dag_generator import (
     create_provider_dags,
-    register_drivers,
     harvest_dags,
 )
-from utils.catalog import fetch_catalog
+from dlme_airflow.drivers import register_drivers
+from dlme_airflow.utils.catalog import fetch_catalog
 
 
 @pytest.fixture


### PR DESCRIPTION
This adds a command line utility for getting the data from a provider/collection as CSV. By default it will print CSV to stdout, which you can redirect or also use `--output` to send to a file.

```
$ bin/get penn penn_egyptian > data.csv
```

This commit touches a lot of files for two reasons:

1. I wanted users to be able to run it with `bin/get` without having to modify PYTHONPATH. All imports that were previously depending on PYTHONPATH being set to `dlme_airflow` now include `dlme_airflow` in the import.
2. I needed to register intake drivers separate from airflow. So I extracted register_drivers() to the dlme_airflow.drivers module.

This functionality is *almost* present in the [intake CLI](https://intake.readthedocs.io/en/latest/tools.html#intake-client), but it doesn't output CSV (just a string representation of the DataFrame). If [this PR](https://github.com/intake/intake/pull/685) gets merged I think we can probably get rid of ours?

Closes #205 