### PR TITLE
Add schedule config option to catalog with @daily default

### DIFF
--- a/catalogs/aims.yaml
+++ b/catalogs/aims.yaml
@@ -1,6 +1,7 @@
 metadata:
   version: 1
   data_path: aims
+  schedule: "0 0 * * *"
 sources:
   aims:
     description: "American Institute for Maghrib Studies"

--- a/dlme_airflow/services/harvest_dag_generator.py
+++ b/dlme_airflow/services/harvest_dag_generator.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from datetime import datetime
@@ -47,10 +48,12 @@ def default_dag_args():
 
 
 def create_dag(provider, default_args):
+    default_schedule = os.getenv("DEFAULT_DAG_SCHEDULE", "@daily")
+
     dag = DAG(
         provider.name,
         default_args=default_args,
-        schedule_interval=provider.catalog.metadata.get("schedule", "@daily"),  # "@once",
+        schedule_interval=provider.catalog.metadata.get("schedule", default_schedule),
         start_date=datetime(2022, 9, 6),
     )
 

--- a/dlme_airflow/services/harvest_dag_generator.py
+++ b/dlme_airflow/services/harvest_dag_generator.py
@@ -50,8 +50,8 @@ def create_dag(provider, default_args):
     dag = DAG(
         provider.name,
         default_args=default_args,
-        schedule_interval="@once",
-        start_date=datetime(2021, 9, 6),
+        schedule_interval=provider.catalog.metadata.get("schedule", "@daily"),  # "@once",
+        start_date=datetime(2022, 9, 6),
     )
 
     with dag:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,6 +67,7 @@ x-airflow-common:
     ECS_SUBNET: "${ECS_SUBNET}"
     S3_BUCKET: "s3://dlme-metadata-dev/metadata"
     SKIP_REPORT: "${SKIP_REPORT}"
+    DEFAULT_DAG_SCHEDULE: "@weekly"
   volumes:
     - ./logs:/opt/airflow/logs
     - ./working:/opt/airflow/working


### PR DESCRIPTION
This introduces the ability to set the DAG schedule in the catalog per provider.

- Adds `schedule` to the provider catalog metadata
- Looks for an `DEFAULT_DAG_SCHEDULE` environment variable set in docker compose or terraform for deployment
- If the `DEFAULT_DAG_SCHEDULE` is missing, defaults to `@daily`

With one collection configured in the catalog and the remainder set by `DEFAULT_DAG_SCHEDULE`:
![Screen Shot 2022-09-08 at 12 02 52 PM](https://user-images.githubusercontent.com/2294288/189205548-0c8deba1-a5e9-47c6-9873-0a8ca13710f0.png)

With one collection configured in the catalog and the remainder set to `@daily` due to missing `DEFAULT_DAG_SCHEDULE`:
![Screen Shot 2022-09-08 at 11 36 34 AM](https://user-images.githubusercontent.com/2294288/189205617-af735378-3093-462a-be97-d41c9b66a5fa.png)
