### PR TITLE
iiif_json.py: more robust handling of non-string types for specified fields

### DIFF
--- a/dlme_airflow/drivers/iiif_json.py
+++ b/dlme_airflow/drivers/iiif_json.py
@@ -54,14 +54,23 @@ class IiifJsonSource(intake.source.base.DataSource):
                 if (
                     len(result) == 1
                 ):  # the JSONPath expression found exactly one result in the manifest
-                    output[name] = result[0].strip()
+                    output[name] = __class__._stringify_and_strip_if_list(result[0])
                 else:  # the JSONPath expression found exactly one result in the manifest
                     if name not in output:
                         output[name] = []
 
                     for data in result:
-                        output[name].append(data.strip())
+                        output[name].append(
+                            __class__._stringify_and_strip_if_list(data)
+                        )
         return output
+
+    @classmethod
+    def _stringify_and_strip_if_list(cls, possible_list) -> list[str]:
+        if isinstance(possible_list, list):
+            return [str(elt).strip() for elt in possible_list]
+        else:
+            return possible_list
 
     def _extract_manifest_metadata(self, iiif_manifest_metadata) -> dict:
         output = {}

--- a/tests/drivers/test_iiif_json.py
+++ b/tests/drivers/test_iiif_json.py
@@ -41,7 +41,7 @@ class MockIIIFManifestResponse:
                     ]
                 }
             ],
-            "description": "A descriptive phrase",
+            "description": ["A descriptive phrase", " with further elaboration "],
         }
 
 
@@ -112,7 +112,7 @@ def test_IiifJsonSource_df(iiif_test_source, mock_response):
         [
             {
                 "context": "http://iiif.io/api/presentation/2/context.json",
-                "description_top": "A descriptive phrase",
+                "description_top": ["A descriptive phrase", "with further elaboration"],
                 "iiif_format": ["image/jpeg", "image/jpeg"],
                 "source": ["Rare Books and Special Collections Library"],
                 "title-main": ["A great title of the Middle East"],


### PR DESCRIPTION
not sure if a list type for a single field value would be valid IIIF, but i ran into this test case when i was trying to cover some of the code paths that were being missed on the iiif_json.py driver (see #214), before i better understood what slightly simpler manifest structure would hit those paths.

we can close this if we never expect to run into data like this, or if this would hide some other problem, or otherwise result in undesired data transformation.

connects with #169