### PR TITLE
Add missing fields that cause ANS to fail harvest

### DIFF
--- a/catalogs/ans.yaml
+++ b/catalogs/ans.yaml
@@ -47,6 +47,8 @@ sources:
           State: object
           Obverse Legend: object
           Obverse Type: object
+          Reverse Legend: object
+          Reverse Type: object
           Date on Object: float64
           Ah: float64
           Axis: float64


### PR DESCRIPTION
Very small PR to add these field DTypes that are causing ANS to fail.

```
ValueError: Mismatched dtypes found in `pd.read_csv`/`pd.read_table`.

+----------------+--------+----------+
| Column         | Found  | Expected |
+----------------+--------+----------+
| Reverse Legend | object | float64  |
| Reverse Type   | object | float64  |
+----------------+--------+----------+

The following columns also raised exceptions on conversion:

- Reverse Legend
  ValueError("could not convert string to float: 'MRA in circle | bismillah zhal-fals | biHalab waf'")
- Reverse Type
  ValueError("could not convert string to float: 'crescent with three stars, scroll, value'")

Usually this is due to dask's dtype inference failing, and
*may* be fixed by specifying dtypes manually by adding:

dtype={'Reverse Legend': 'object',
       'Reverse Type': 'object'}
```