### PR TITLE
Separate DAGS

### DIFF
--- a/catalogs/auc.yaml
+++ b/catalogs/auc.yaml
@@ -1,6 +1,7 @@
 metadata:
   version: 1
   data_path: auc
+  separate_dags: true
 sources:
   al_musawwar:
     description: "Al-Musawwar Magazine Collection"

--- a/dlme_airflow/models/provider.py
+++ b/dlme_airflow/models/provider.py
@@ -14,6 +14,9 @@ class Provider(object):
                 return coll
         return None
 
+    def label(self):
+        return self.name
+
     def data_path(self):
         return self.catalog.metadata.get("data_path", self.name)
 

--- a/dlme_airflow/services/harvest_dag_generator.py
+++ b/dlme_airflow/services/harvest_dag_generator.py
@@ -1,9 +1,10 @@
 import os
 import sys
+import logging
 
+from typing import Union
 from datetime import datetime
 from datetime import timedelta
-import logging
 
 # Operators and utils required from airflow
 from airflow import DAG
@@ -11,9 +12,12 @@ from airflow.operators.dummy import DummyOperator
 from airflow.models import Variable
 
 # Our stuff
-from dlme_airflow.models.provider import Provider
-from dlme_airflow.task_groups.etl import build_provider_etl_taskgroup
+from dlme_airflow.models.provider import Provider, Collection
 from dlme_airflow.utils.catalog import fetch_catalog
+from dlme_airflow.task_groups.etl import (
+    build_provider_etl_taskgroup,
+    build_collection_etl_taskgroup,
+)
 
 
 _harvest_dags: dict[str, DAG] = dict()
@@ -40,52 +44,67 @@ def default_dag_args():
     }
 
 
-def create_dag(provider, default_args) -> DAG:
+def create_dags(provider) -> list[DAG]:
+    """Returns a list of DAGs for a given provider."""
+    dags = []
+    if provider.catalog.metadata.get("separate_dags"):
+        # create a DAG for each collection, which can be useful if you want to
+        # schedule them separately
+        for collection in provider.collections:
+            dags.append(assemble_dag(collection))
+    else:
+        # create a single DAG for the provider and all its collections which
+        # will all run in parallel
+        dags.append(assemble_dag(provider))
+    return dags
+
+
+def assemble_dag(source: Union[Provider, Collection]):
+    """Returns a DAG for either a Provider or a Collection."""
+    default_args = default_dag_args()
     default_schedule = os.getenv("DEFAULT_DAG_SCHEDULE", "@daily")
 
-    dag = DAG(
-        provider.name,
-        default_args=default_args,
-        schedule_interval=provider.catalog.metadata.get("schedule", default_schedule),
-        start_date=datetime(2022, 9, 6),
-    )
+    schedule = source.catalog.metadata.get("schedule", default_schedule)
+    start_date = datetime(2022, 9, 6)
+    dag_id = source.label()
 
-    with dag:
-        # A dummy operator is required as a transition point between task groups
+    with DAG(
+        dag_id,
+        default_args=default_args,
+        schedule_interval=schedule,
+        start_date=start_date,
+    ) as dag:
         harvest_begin = DummyOperator(
-            task_id="harvest_begin", trigger_rule="none_failed", dag=dag
+            task_id="harvest_begin", trigger_rule="none_failed"
         )
         harvest_complete = DummyOperator(
-            task_id="harvest_complete", trigger_rule="none_failed", dag=dag
+            task_id="harvest_complete", trigger_rule="none_failed"
         )
-
-        # TODO
-        # post_harvest_begin = DummyOperator(task_id='post_harvest_begin', trigger_rule='none_failed', dag=dag)
-        # post_harvest = build_post_havest_taskgroup(provider, dag)
-        # post_harvest_complete = DummyOperator(task_id='post_harvest_complete', trigger_rule='none_failed', dag=dag)
-
-        # TODO: A dummy operator is required as a transition point between task groups
-        # post_harvest_complete = DummyOperator(task_id='post_harvest_complete', trigger_rule='none_failed', dag=dag)
-
-        etl = build_provider_etl_taskgroup(provider, dag)
-
+        if type(source) == Provider:
+            etl = build_provider_etl_taskgroup(source, dag)
+        elif type(source) == Collection:
+            etl = build_collection_etl_taskgroup(source, dag)
+        else:
+            raise Exception("source must be a Provider or a Collection")
         harvest_begin >> etl >> harvest_complete
 
     return dag
 
 
 def create_provider_dags(module_name=None):
-    for provider in iter(list(fetch_catalog())):
+    """Create all the DAGs optionally in a given module namespace so that
+    Airflow can discover them.
+    """
+    for provider in fetch_catalog():
         current_provider = Provider(provider)
         logging.info(f"Creating DAG for {current_provider.name}")
 
-        dag = create_dag(current_provider, default_dag_args())
-        if module_name is None:
-            globals()[provider] = dag
-        else:
-            logging.info(f"setting {module_name}.{provider} to {dag}")
-            setattr(sys.modules[module_name], provider, dag)
-
-        _harvest_dags[provider] = dag
+        dags = create_dags(current_provider)
+        for dag in dags:
+            if module_name is None:
+                globals()[dag.dag_id] = dag
+            else:
+                setattr(sys.modules[module_name], dag.dag_id, dag)
+            _harvest_dags[dag.dag_id] = dag
 
     logging.info(f"_harvest_dags={_harvest_dags}")

--- a/dlme_airflow/task_groups/etl.py
+++ b/dlme_airflow/task_groups/etl.py
@@ -18,29 +18,24 @@ from dlme_airflow.task_groups.validate_dlme_metadata import (
 )
 
 
-def etl_tasks(provider, task_group: TaskGroup, dag: DAG) -> list[TaskGroup]:
+def etl_tasks(provider, dag: DAG) -> list[TaskGroup]:
     task_array = []
     for collection in provider.collections:
-        task_array.append(
-            build_collection_etl_taskgroup(provider, collection, task_group, dag)
-        )
+        task_array.append(build_collection_etl_taskgroup(collection, dag))
 
     return task_array
 
 
 def build_provider_etl_taskgroup(provider, dag: DAG) -> TaskGroup:
-
     with TaskGroup(
         group_id=f"{provider.name.upper()}_ETL", dag=dag
     ) as provider_etl_taskgroup:
-        etl_tasks(provider, provider_etl_taskgroup, dag)
+        etl_tasks(provider, dag)
 
     return provider_etl_taskgroup
 
 
-def build_collection_etl_taskgroup(
-    provider, collection, task_group: TaskGroup, dag: DAG
-) -> TaskGroup:
+def build_collection_etl_taskgroup(collection, dag: DAG) -> TaskGroup:
     post_harvest = collection.catalog.metadata.get("post_harvest", None)
 
     with TaskGroup(

--- a/dlme_airflow/tasks/post_harvest.py
+++ b/dlme_airflow/tasks/post_harvest.py
@@ -5,6 +5,7 @@ from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.task_group import TaskGroup
 
+# While it looks like they're not used these are called dynamically by run_post_harvest
 from dlme_airflow.utils.add_thumbnails import add_thumbnails
 from dlme_airflow.utils.qnl_merge_records import (
     merge_records,

--- a/tests/services/test_harvest_dag_generator.py
+++ b/tests/services/test_harvest_dag_generator.py
@@ -8,7 +8,6 @@ from dlme_airflow.services.harvest_dag_generator import (
     harvest_dags,
 )
 from dlme_airflow.drivers import register_drivers
-from dlme_airflow.utils.catalog import fetch_catalog
 
 
 @pytest.fixture
@@ -23,7 +22,5 @@ def mock_variable(monkeypatch):
 def test_create_provider_dags(mock_variable):
     register_drivers()
     create_provider_dags()
-    assert list(harvest_dags().keys()) == list(fetch_catalog())
-    for provider in iter(list(fetch_catalog())):
-        dag = harvest_dags()[provider]
+    for dag in harvest_dags().values():
         check_cycle(dag)


### PR DESCRIPTION
Adds the Provider intake configuration option `separate_dags` which when it is set to `true` will cause the collections to run as individual DAGS rather than as TaskGroup which parallelizes them all. This will allow for separate scheduling of the individual DAGs to avoid situations where many concurrent requests are being made to the same Provider server.

Closes #131
