### PR TITLE
Fix order of config for BNF

### DIFF
--- a/catalogs/bnf.yaml
+++ b/catalogs/bnf.yaml
@@ -11,8 +11,8 @@ sources:
       config: bnf_config
       record_selector:
         path: "//srw:record"
-          srw: "http://www.loc.gov/zing/srw/"
         namespace:
+          srw: "http://www.loc.gov/zing/srw/"
         optional: false
       fields:
         id:


### PR DESCRIPTION
The srw namespace config field is configured under `path` but needs to be under `namespace`