### PR TITLE
Add test coverage for Provider and Collection 

### DIFF
--- a/dlme_airflow/utils/catalog.py
+++ b/dlme_airflow/utils/catalog.py
@@ -11,6 +11,9 @@ def fetch_catalog():
 
 
 def catalog_for_provider(provider):
-    return getattr(
-        fetch_catalog(), provider
-    )  # Raises Attribute error for missing provider
+    try:
+        return getattr(
+            fetch_catalog(), provider
+        )  # Raises Attribute error for missing provider
+    except AttributeError:
+        raise ValueError(f"Provider ({provider}) not found in catalog")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+from dlme_airflow.drivers import register_drivers
+
+register_drivers()

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -1,0 +1,23 @@
+import pytest
+
+from dlme_airflow.models.collection import Collection
+from dlme_airflow.models.provider import Provider
+
+
+def test_Collection():
+    provider = Provider("aub")
+    collection = Collection(provider, "aco")
+    assert collection.label() == "aub_aco"
+    assert collection.data_path() == "aub/aco"
+    assert (
+        collection.intermidiate_representation_location()
+        == "https://dlme-metadata-dev.s3.us-west-2.amazonaws.com/output/output-aub/aco.ndjson"
+    )
+
+
+def test_Provider_NotFound():
+    with pytest.raises(ValueError) as error:
+        provider = Provider("aub")
+        Collection(provider, "amc")
+
+    assert str(error.value) == "Provider (aub.amc) not found in catalog"

--- a/tests/models/test_provider.py
+++ b/tests/models/test_provider.py
@@ -1,0 +1,17 @@
+import pytest
+
+from dlme_airflow.models.provider import Provider
+
+
+def test_Provider():
+    provider = Provider("aims")
+    assert provider.label() == "aims"
+    assert provider.data_path() == "aims"
+    assert len(provider.collections) == 1
+
+
+def test_Provider_NotFound():
+    with pytest.raises(ValueError) as error:
+        Provider("does_not_exist")
+
+    assert str(error.value) == "Provider (does_not_exist) not found in catalog"

--- a/tests/services/test_harvest_dag_generator.py
+++ b/tests/services/test_harvest_dag_generator.py
@@ -7,7 +7,6 @@ from dlme_airflow.services.harvest_dag_generator import (
     create_provider_dags,
     harvest_dags,
 )
-from dlme_airflow.drivers import register_drivers
 
 
 @pytest.fixture
@@ -20,7 +19,6 @@ def mock_variable(monkeypatch):
 
 
 def test_create_provider_dags(mock_variable):
-    register_drivers()
     create_provider_dags()
     for dag in harvest_dags().values():
         check_cycle(dag)


### PR DESCRIPTION
This adds tests for the Provider and Collection models. It also establishes `conftest.py` at the tests root path for global test setup. See: https://docs.pytest.org/en/6.2.x/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session. 

Additionally, this updates the raise if a provider or collection is not found in the catalog in order to better control and test the error message.