### PR TITLE
XML Driver fixes

### DIFF
--- a/catalogs/aims.yaml
+++ b/catalogs/aims.yaml
@@ -10,7 +10,7 @@ sources:
       data_path: aims
       config: aims_config
       record_selector:
-        path: "//item"
+        path: ".//item"
         namespace:
       fields:
         id:

--- a/catalogs/bnf.yaml
+++ b/catalogs/bnf.yaml
@@ -6,42 +6,96 @@ sources:
   ideo:
     description: "The Bibliothèque nationale de France"
     driver: xml
+    args:
+      collection_url: https://gallica.bnf.fr/SRU?operation=searchRetrieve&version=1.2&query=%28%28bibliotheque%20adj%20%22Institut%20dominicain%20d%27%C3%A9tudes%20orientales%22%29%29#resultat-id-3
     metadata:
       data_path: bnf/ideo
       config: bnf_config
       record_selector:
-        path: "//srw:record"
+        path: ".//oai_dc:dc"
         namespace:
-          srw: "http://www.loc.gov/zing/srw/"
+          oai_dc: http://www.openarchives.org/OAI/2.0/oai_dc/
         optional: false
       fields:
         id:
-          path: ".//srw:recordSchema"
+          path: "dc:identifier"
           namespace:
             dc: "http://purl.org/dc/elements/1.1/"
-            oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/"
-            srw: "http://www.loc.gov/zing/srw/"
-          optional: false
-    args:
-      collection_url: https://gallica.bnf.fr/SRU?operation=searchRetrieve&version=1.2&query=%28%28bibliotheque%20adj%20%22Institut%20dominicain%20d%27%C3%A9tudes%20orientales%22%29%29#resultat-id-3
+        title:
+          path: "dc:title"
+          namespace:
+            dc: "http://purl.org/dc/elements/1.1/"
+        creator:
+          path: "dc:creator"
+          namespace:
+            dc: "http://purl.org/dc/elements/1.1/"
+          optional: true
+        contributor:
+          path: "dc:contributor"
+          namespace:
+            dc: "http://purl.org/dc/elements/1.1/"
+          optional: true
+        date:
+          path: "dc:date"
+          namespace:
+            dc: "http://purl.org/dc/elements/1.1/"
+          optional: true
+        description:
+          path: "dc:description"
+          namespace:
+            dc: "http://purl.org/dc/elements/1.1/"
+          optional: true
+        format:
+          path: "dc:description"
+          namespace:
+            dc: "http://purl.org/dc/elements/1.1/"
+          optional: true
+        language:
+          path: "dc:language"
+          namespace:
+            dc: "http://purl.org/dc/elements/1.1/"
+          optional: true
+        subject:
+          path: "dc:subject"
+          namespace:
+            dc: "http://purl.org/dc/elements/1.1/"
+          optional: true
+        type:
+          path: "dc:type"
+          namespace:
+            dc: "http://purl.org/dc/elements/1.1/"
+          optional: true
   ifao:
     description: "The Bibliothèque nationale de France"
     driver: xml
+    args:
+      collection_url: https://feed.podbean.com/themaghribpodcast/feed.xml
     metadata:
       data_path: bnf/ifao
       config: bnf_config
       record_selector:
-        path: "//srw:record"
+        path: ".//item"
         namespace:
-          srw: "http://www.loc.gov/zing/srw/"
+          oai_dc: http://www.openarchives.org/OAI/2.0/oai_dc/
         optional: false
       fields:
         id:
-          path: ".//srw:recordSchema"
-          namespace:
-            dc: "http://purl.org/dc/elements/1.1/"
-            oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/"
-            srw: "http://www.loc.gov/zing/srw/"
+          path: "link"
           optional: false
-    args:
-      collection_url: https://feed.podbean.com/themaghribpodcast/feed.xml
+        title:
+          path: "title"
+        summary:
+          path: "itunes:summary"
+          namespace:
+            itunes: http://www.itunes.com/dtds/podcast-1.0.dtd
+        image:
+          path: "image/url"
+          optional: true
+        audio:
+          path: "enclosure/@url"
+          optional: true
+        duration:
+          path: "itunes:duration"
+          namespace:
+            itunes: http://www.itunes.com/dtds/podcast-1.0.dtd
+          optional: true

--- a/catalogs/shahre_farang.yaml
+++ b/catalogs/shahre_farang.yaml
@@ -10,7 +10,7 @@ sources:
       data_path: shahre_farang/arabic
       config: shahre_farang_config
       record_selector:
-        path: "//item"
+        path: ".//item"
         namespace:
       fields:
         id:
@@ -52,7 +52,7 @@ sources:
       data_path: shahre_farang/english
       config: shahre_farang_config
       record_selector:
-        path: "//item"
+        path: ".//item"
         namespace:
       fields:
         id:
@@ -94,7 +94,7 @@ sources:
       data_path: shahre_farang/persian
       config: shahre_farang_config
       record_selector:
-        path: "//item"
+        path: ".//item"
         namespace:
       fields:
         id:


### PR DESCRIPTION
This commit addresses some things that the bnf.yaml difficulties made clear.
The `record_selector` was being defined in the intake catalog entries but it
wasn't actually being used by the XML Driver. Once it was being used it needs
to start with a `.` so for example `.//item`, because it is searching on the
root element at first. This isn't needed in subsequent XPaths.

I updated the bnf entries but these should probably be checked. I mostly
wanted to test that the XPaths were working correctly.
