### PR TITLE
Do not include catalogs in coverage calculations

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+exclude_patterns:
+- "catalogs/"
+- "tests/"


### PR DESCRIPTION
This excludes `catalogs/` from coverage calculations. `tests/` is covered by default, however, with this file established we have to declare it as well.