### PR TITLE
Implement wait option for OaiXmlSource

### DIFF
--- a/bin/get
+++ b/bin/get
@@ -39,7 +39,10 @@ if __name__ == "__main__":
     parser.add_argument('collection', help="The provider's collection (e.g. penn_egyptian")
     parser.add_argument("--output", help="File to write CSV output to")
     parser.add_argument("--limit", type=int, help="Limit output to number of rows")
+    parser.add_argument("--log", default="get.log", help="A file path to write log messages")
     opts = parser.parse_args()
+
+    logging.basicConfig(filename=opts.log, format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO)
 
     # Ignore broken pipe errors when running from the command line.
     # This allows: bin/get penn penn_babylonian | head -10

--- a/catalogs/qnl.yaml
+++ b/catalogs/qnl.yaml
@@ -8,7 +8,7 @@ sources:
     args:
       collection_url: https://api.qdl.qa/api/oaipmh
       metadata_prefix: mods_no_ocr
-      set:
+      wait: 2
     metadata:
       data_path: qnl/british-library-combined
       post_harvest: "merge_records"

--- a/tests/drivers/test_oai_xml.py
+++ b/tests/drivers/test_oai_xml.py
@@ -67,3 +67,9 @@ def test_marc21(mock_marc21):
     assert len(df) == 182, "expected number of rows"
     assert len(df.columns) == 92, "expected number of columns"
     assert "245_a" in df.columns, "marc field 245 subfield a extracted"
+
+
+def test_wait(mock_oai_dc):
+    # ensure that the wait option can be used
+    oai = OaiXmlSource("https://example.org", "oai_dc", wait=2)
+    assert oai


### PR DESCRIPTION
This adds a wait option for the OaiXmlSource driver which will inject a sleep of n seconds between sending HTTP requests to the OAI server.

Sickle allows you to pass in your own iterator class, which gets used internally when making requests. This class needs to change its behavior depending on the desired wait time, so it is created dynamically by the make_iterator() function.

The QNL intake catalog entry has been adjusted to use `wait: 2` which fixes #200.

I also added a `--log` option to bin/get to write the sleep messages (and other diagnostics) to a file.

Closes #235
