### PR TITLE
Establish data flow with harvest validation

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,8 @@
+checks:
+  method-complexity:
+    config:
+      threshold: 6
+
 exclude_patterns:
 - "catalogs/"
 - "tests/"

--- a/dlme_airflow/harvester/source_harvester.py
+++ b/dlme_airflow/harvester/source_harvester.py
@@ -14,4 +14,4 @@ def data_source_harvester(**kwargs):
 
     collection = kwargs.get("collection")
     # dataframe_to_file(source, collection.provider.name, collection)
-    dataframe_to_file(collection)
+    return dataframe_to_file(collection)

--- a/dlme_airflow/task_groups/etl.py
+++ b/dlme_airflow/task_groups/etl.py
@@ -7,7 +7,6 @@ from airflow import DAG
 # Operators and utils required from airflow
 from airflow.utils.task_group import TaskGroup
 from airflow.operators.dummy import DummyOperator
-from airflow.operators.python import BranchPythonOperator
 
 from dlme_airflow.tasks.harvest import build_harvester_task
 from dlme_airflow.tasks.post_harvest import build_post_harvest_task
@@ -50,17 +49,13 @@ def build_collection_etl_taskgroup(collection, dag: DAG) -> TaskGroup:
         index = index_task(collection, collection_etl_taskgroup, dag)
 
         etl_complete = DummyOperator(task_id="etl_complete", trigger_rule="none_failed")
-        skip_load_data = DummyOperator(task_id="skip_load_data", trigger_rule="none_failed")
+        skip_load_data = DummyOperator(
+            task_id="skip_load_data", trigger_rule="none_failed"
+        )
         load_data = DummyOperator(task_id="load_data", trigger_rule="none_failed")
-        validate_harvest_task = build_validate_harvest_task(collection, collection_etl_taskgroup, dag)
-        # validate_harvest_task = BranchPythonOperator(
-        #     task_id="validate_harvest",
-        #     task_group=collection_etl_taskgroup,
-        #     python_callable=validate_harvest,
-        #     op_kwargs = {
-        #         "collection": collection
-        #     }
-        # )
+        validate_harvest_task = build_validate_harvest_task(
+            collection, collection_etl_taskgroup, dag
+        )
 
         # harvest and sync with an optional post_harvest_task if catalog metadata wants it
         if post_harvest:

--- a/dlme_airflow/tasks/harvest_validator.py
+++ b/dlme_airflow/tasks/harvest_validator.py
@@ -8,6 +8,7 @@ from dlme_airflow.utils.dataframe import dataframe_from_s3
 
 
 def validate_harvest(task_instance, task, **kwargs):
+    task_prefix = ".".join(task.task_id.split(".")[:-1])
     collection = kwargs["collection"]
     current_harvest = pd.read_csv(
         task_instance.xcom_pull(task_ids=task.upstream_task_ids)[0]
@@ -15,9 +16,9 @@ def validate_harvest(task_instance, task, **kwargs):
     previous_harvest = dataframe_from_s3(collection)
 
     if current_harvest.equals(previous_harvest):
-        return f"{collection.provider.name.upper()}_ETL.{collection.name}_etl.skip_load_data"
+        return f"{task_prefix}.skip_load_data"
     else:
-        return f"{collection.provider.name.upper()}_ETL.{collection.name}_etl.load_data"
+        return f"{task_prefix}.load_data"
 
 
 def build_validate_harvest_task(collection, task_group: TaskGroup, dag: DAG):

--- a/dlme_airflow/tasks/harvest_validator.py
+++ b/dlme_airflow/tasks/harvest_validator.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+from airflow import DAG
+from airflow.operators.python import BranchPythonOperator
+from airflow.utils.task_group import TaskGroup
+
+from dlme_airflow.utils.dataframe import dataframe_from_s3
+
+
+def validate_harvest(task_instance, task, **kwargs):
+    collection = kwargs["collection"]
+    current_harvest = pd.read_csv(task_instance.xcom_pull(task_ids=task.upstream_task_ids)[0])
+    previous_harvest = dataframe_from_s3(collection)
+
+    if current_harvest.equals(previous_harvest):
+        return f"{collection.provider.name.upper()}_ETL.{collection.name}_etl.skip_load_data"
+    else:
+        return f"{collection.provider.name.upper()}_ETL.{collection.name}_etl.load_data"
+
+
+def build_validate_harvest_task(collection, task_group: TaskGroup, dag: DAG):
+      return BranchPythonOperator(
+        task_id=f"{collection.label()}_validate_harvest",
+        dag=dag,
+        task_group=task_group,
+        python_callable=validate_harvest,
+        op_kwargs={"collection": collection},
+    )

--- a/dlme_airflow/tasks/harvest_validator.py
+++ b/dlme_airflow/tasks/harvest_validator.py
@@ -9,7 +9,9 @@ from dlme_airflow.utils.dataframe import dataframe_from_s3
 
 def validate_harvest(task_instance, task, **kwargs):
     collection = kwargs["collection"]
-    current_harvest = pd.read_csv(task_instance.xcom_pull(task_ids=task.upstream_task_ids)[0])
+    current_harvest = pd.read_csv(
+        task_instance.xcom_pull(task_ids=task.upstream_task_ids)[0]
+    )
     previous_harvest = dataframe_from_s3(collection)
 
     if current_harvest.equals(previous_harvest):
@@ -19,7 +21,7 @@ def validate_harvest(task_instance, task, **kwargs):
 
 
 def build_validate_harvest_task(collection, task_group: TaskGroup, dag: DAG):
-      return BranchPythonOperator(
+    return BranchPythonOperator(
         task_id=f"{collection.label()}_validate_harvest",
         dag=dag,
         task_group=task_group,

--- a/dlme_airflow/utils/dataframe.py
+++ b/dlme_airflow/utils/dataframe.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import pandas as pd
 import boto3
@@ -25,9 +24,8 @@ def dataframe_from_s3(collection) -> pd.DataFrame:
 #       the metadata. Need to handle this error.
 def dataframe_to_file(collection):
     working_csv = os.path.join(
-        os.path.abspath("metadata"),
-        collection.data_path(),
-        "data.csv")
+        os.path.abspath("metadata"), collection.data_path(), "data.csv"
+    )
     os.makedirs(os.path.dirname(working_csv), exist_ok=True)
 
     unique_id = (
@@ -43,7 +41,7 @@ def dataframe_to_file(collection):
     return working_csv
 
 
-## TODO:
-##    - Add a dataframe_from_file matching the above s3 method
-##    - Add a dataframe_changed? method compairing old and new
-##    -- Consider moving the dataframe_to_file call into the collection model (i.e. collection.to_csv will call dataframe_to_file)
+# TODO:
+#    - Add a dataframe_from_file matching the above s3 method
+#    - Add a dataframe_changed? method compairing old and new
+#    -- Consider moving the dataframe_to_file call into the collection model (i.e. collection.to_csv will call dataframe_to_file)

--- a/dlme_airflow/utils/dataframe.py
+++ b/dlme_airflow/utils/dataframe.py
@@ -39,9 +39,3 @@ def dataframe_to_file(collection):
     source_df.to_csv(working_csv, index=False)
 
     return working_csv
-
-
-# TODO:
-#    - Add a dataframe_from_file matching the above s3 method
-#    - Add a dataframe_changed? method compairing old and new
-#    -- Consider moving the dataframe_to_file call into the collection model (i.e. collection.to_csv will call dataframe_to_file)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -73,6 +73,7 @@ x-airflow-common:
     ECS_SUBNET: "${ECS_SUBNET}"
     S3_BUCKET: "dlme-metadata-dev"
     SKIP_REPORT: "${SKIP_REPORT}"
+    SKIP_HARVEST_VALIDATION: "true"
     DEFAULT_DAG_SCHEDULE: "@weekly"
   volumes:
     - ./logs:/opt/airflow/logs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -71,7 +71,7 @@ x-airflow-common:
     DEV_ROLE_ARN: "${DEV_ROLE_ARN}"
     ECS_SECURITY_GROUP: "${ECS_SECURITY_GROUP}"
     ECS_SUBNET: "${ECS_SUBNET}"
-    S3_BUCKET: "s3://dlme-metadata-dev/metadata"
+    S3_BUCKET: "dlme-metadata-dev"
     SKIP_REPORT: "${SKIP_REPORT}"
     DEFAULT_DAG_SCHEDULE: "@weekly"
   volumes:

--- a/tests/tasks/test_harvest_validator.py
+++ b/tests/tasks/test_harvest_validator.py
@@ -1,0 +1,79 @@
+import boto3
+import botocore.session
+import io
+import os
+import pytest
+import mock
+
+from botocore.response import StreamingBody
+from botocore.stub import Stubber
+from dlme_airflow.tasks.harvest_validator import validate_harvest
+from dlme_airflow.models.collection import Collection
+from dlme_airflow.models.provider import Provider
+from mock import patch
+from airflow.models.taskinstance import TaskInstance
+from airflow.models.baseoperator import BaseOperator
+
+@pytest.fixture
+def mock_boto3(monkeypatch):
+    def mock_client(_type):
+        expected_message = b"column1,column2,column3\n1,2,3\n4,5,6"
+
+        raw_stream = StreamingBody(io.BytesIO(expected_message), len(expected_message))
+
+        response = {"Body": raw_stream}
+
+        expected_params = {
+            "Bucket": "test-bucket",
+            "Key": "metadata/provider/collection/data.csv",
+        }
+
+        s3 = botocore.session.get_session().create_client("s3")
+        stubber = Stubber(s3)
+
+        stubber.add_response("get_object", response, expected_params)
+        stubber.activate()
+
+        return s3
+
+    monkeypatch.setattr(boto3, "client", mock_client)
+
+
+@pytest.fixture
+def mock_provider(monkeypatch):
+    monkeypatch.setattr(Provider, "name", "provider")
+
+
+@pytest.fixture
+def mock_collection(monkeypatch, mock_provider):
+    monkeypatch.setattr(Collection, "provider", mock_provider)
+    monkeypatch.setattr(Collection, "name", "collection")
+    monkeypatch.setattr(Collection, "data_path", "provider/collection")
+
+def test_validate_harvest(mock_boto3, mock_collection):
+    # with mock.patch("dlme_airflow.models.provider.Provider") as mock:, new_callable=mock.PropertyMock, return_value="my value"):
+    # @mock.patch('Provider.name', return_value="provider")
+    # @mock.patch('Collection.name', return_value="collection")
+    os.environ["S3_BUCKET"] = "test-bucket"
+    mock_task_instance = mock.Mock()
+    mock_task = mock.Mock()
+    mock_task_instance.xcom_pull.return_value = [os.path.join(os.path.abspath("tests"), "data", "csv", "example1.csv")]
+    mock_task.upstream_task_ids = ["task_id_1", "task_id_2"]
+    with patch("dlme_airflow.models.provider.Provider.name", new_callable=mock.PropertyMock, return_value="provider") as mock_provider_name:
+    # with patch("dlme_airflow.models.provider.Provider.name", new_callable=mock.PropertyMock, return_value="provider") as mock_provider_name:
+    #   with patch("dlme_airflow.models.provider.Provider") as mock_provider:
+    #       mock_provider.name.return_value = "provider"
+    #       with patch("dlme_airflow.models.collection.Collection") as mock_collection:
+    #         mock_collection.data_path.return_value = "provider/collection"
+    #         mock_collection.provider.return_value = mock_provider
+    #         mock_collection.name.return_value = "collection"
+    next_task = validate_harvest(mock_task_instance, mock_task, collection = mock_collection)
+
+    assert next_task == "something.something.something"
+
+    # mock_collection = mock.Mock()
+    # mock_provider = mock.Mock()
+    # mock_provider.name.return_value = "provider"
+    # mock_collection.data_path.return_value = "provider/collection"
+    # mock_collection.provider.return_value = mock_provider
+    # mock_collection.name.return_value = "collection"

--- a/tests/tasks/test_harvest_validator.py
+++ b/tests/tasks/test_harvest_validator.py
@@ -25,7 +25,7 @@ def mock_boto3(monkeypatch):
 
         expected_params = {
             "Bucket": "test-bucket",
-            "Key": "metadata/provider/collection/data.csv",
+            "Key": "metadata/aims/data.csv",
         }
 
         s3 = botocore.session.get_session().create_client("s3")
@@ -39,18 +39,18 @@ def mock_boto3(monkeypatch):
     monkeypatch.setattr(boto3, "client", mock_client)
 
 
-@pytest.fixture
-def mock_collection(monkeypatch):
-    def mock_data_path(self):
-        return "provider/collection"
+# @pytest.fixture
+# def mock_collection(monkeypatch):
+#     def mock_data_path(self):
+#         return "provider/collection"
 
-    monkeypatch.setattr(Collection, "data_path", mock_data_path)
+#     monkeypatch.setattr(Collection, "data_path", mock_data_path)
 
 
-def test_validate_harvest_skip_load_data(mock_boto3, mock_collection):
+def test_validate_harvest_skip_load_data(mock_boto3):
     os.environ["S3_BUCKET"] = "test-bucket"
-    test_provider = Provider("provider")
-    test_collection = Collection(test_provider, "collection")
+    test_provider = Provider("aims")
+    test_collection = Collection(test_provider, "aims")
     mock_task_instance = mock.Mock()
     mock_task = mock.Mock()
     mock_task_instance.xcom_pull.return_value = [
@@ -61,13 +61,13 @@ def test_validate_harvest_skip_load_data(mock_boto3, mock_collection):
         mock_task_instance, mock_task, collection=test_collection
     )
 
-    assert next_task == "PROVIDER_ETL.collection_etl.skip_load_data"
+    assert next_task == "AIMS_ETL.aims_etl.skip_load_data"
 
 
-def test_validate_harvest_load_data(mock_boto3, mock_collection):
+def test_validate_harvest_load_data(mock_boto3):
     os.environ["S3_BUCKET"] = "test-bucket"
-    test_provider = Provider("provider")
-    test_collection = Collection(test_provider, "collection")
+    test_provider = Provider("aims")
+    test_collection = Collection(test_provider, "aims")
     mock_task_instance = mock.Mock()
     mock_task = mock.Mock()
     mock_task_instance.xcom_pull.return_value = [
@@ -78,4 +78,4 @@ def test_validate_harvest_load_data(mock_boto3, mock_collection):
         mock_task_instance, mock_task, collection=test_collection
     )
 
-    assert next_task == "PROVIDER_ETL.collection_etl.load_data"
+    assert next_task == "AIMS_ETL.aims_etl.load_data"

--- a/tests/tasks/test_harvest_validator.py
+++ b/tests/tasks/test_harvest_validator.py
@@ -10,14 +10,14 @@ from botocore.stub import Stubber
 from dlme_airflow.tasks.harvest_validator import validate_harvest
 from dlme_airflow.models.collection import Collection
 from dlme_airflow.models.provider import Provider
-from mock import patch
-from airflow.models.taskinstance import TaskInstance
-from airflow.models.baseoperator import BaseOperator
+
 
 @pytest.fixture
 def mock_boto3(monkeypatch):
     def mock_client(_type):
-        expected_message = b"column1,column2,column3\n1,2,3\n4,5,6"
+        expected_message = (
+            b"id,title\n1,Example 1\n2,Example 2\n3,Example 3\n4,Example 4"
+        )
 
         raw_stream = StreamingBody(io.BytesIO(expected_message), len(expected_message))
 
@@ -40,40 +40,25 @@ def mock_boto3(monkeypatch):
 
 
 @pytest.fixture
-def mock_provider(monkeypatch):
-    monkeypatch.setattr(Provider, "name", "provider")
+def mock_collection(monkeypatch):
+    def mock_data_path(self):
+        return "provider/collection"
 
+    monkeypatch.setattr(Collection, "data_path", mock_data_path)
 
-@pytest.fixture
-def mock_collection(monkeypatch, mock_provider):
-    monkeypatch.setattr(Collection, "provider", mock_provider)
-    monkeypatch.setattr(Collection, "name", "collection")
-    monkeypatch.setattr(Collection, "data_path", "provider/collection")
 
 def test_validate_harvest(mock_boto3, mock_collection):
-    # with mock.patch("dlme_airflow.models.provider.Provider") as mock:, new_callable=mock.PropertyMock, return_value="my value"):
-    # @mock.patch('Provider.name', return_value="provider")
-    # @mock.patch('Collection.name', return_value="collection")
     os.environ["S3_BUCKET"] = "test-bucket"
+    test_provider = Provider("provider")
+    test_collection = Collection(test_provider, "collection")
     mock_task_instance = mock.Mock()
     mock_task = mock.Mock()
-    mock_task_instance.xcom_pull.return_value = [os.path.join(os.path.abspath("tests"), "data", "csv", "example1.csv")]
+    mock_task_instance.xcom_pull.return_value = [
+        os.path.join(os.path.abspath("tests"), "data", "csv", "example1.csv")
+    ]
     mock_task.upstream_task_ids = ["task_id_1", "task_id_2"]
-    with patch("dlme_airflow.models.provider.Provider.name", new_callable=mock.PropertyMock, return_value="provider") as mock_provider_name:
-    # with patch("dlme_airflow.models.provider.Provider.name", new_callable=mock.PropertyMock, return_value="provider") as mock_provider_name:
-    #   with patch("dlme_airflow.models.provider.Provider") as mock_provider:
-    #       mock_provider.name.return_value = "provider"
-    #       with patch("dlme_airflow.models.collection.Collection") as mock_collection:
-    #         mock_collection.data_path.return_value = "provider/collection"
-    #         mock_collection.provider.return_value = mock_provider
-    #         mock_collection.name.return_value = "collection"
-    next_task = validate_harvest(mock_task_instance, mock_task, collection = mock_collection)
+    next_task = validate_harvest(
+        mock_task_instance, mock_task, collection=test_collection
+    )
 
-    assert next_task == "something.something.something"
-
-    # mock_collection = mock.Mock()
-    # mock_provider = mock.Mock()
-    # mock_provider.name.return_value = "provider"
-    # mock_collection.data_path.return_value = "provider/collection"
-    # mock_collection.provider.return_value = mock_provider
-    # mock_collection.name.return_value = "collection"
+    assert next_task == "PROVIDER_ETL.collection_etl.skip_load_data"

--- a/tests/tasks/test_harvest_validator.py
+++ b/tests/tasks/test_harvest_validator.py
@@ -53,6 +53,7 @@ def test_validate_harvest_skip_load_data(mock_boto3):
     test_collection = Collection(test_provider, "aims")
     mock_task_instance = mock.Mock()
     mock_task = mock.Mock()
+    mock_task.task_id = "AIMS_ETL.aims_etl.aims_aims_validate_harvest"
     mock_task_instance.xcom_pull.return_value = [
         os.path.join(os.path.abspath("tests"), "data", "csv", "example1.csv")
     ]
@@ -70,6 +71,7 @@ def test_validate_harvest_load_data(mock_boto3):
     test_collection = Collection(test_provider, "aims")
     mock_task_instance = mock.Mock()
     mock_task = mock.Mock()
+    mock_task.task_id = "AIMS_ETL.aims_etl.aims_aims_validate_harvest"
     mock_task_instance.xcom_pull.return_value = [
         os.path.join(os.path.abspath("tests"), "data", "csv", "example2.csv")
     ]

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -20,7 +20,7 @@ def mock_boto3(monkeypatch):
 
         expected_params = {
             "Bucket": "test-bucket",
-            "Key": "provider/collection/data.csv",
+            "Key": "metadata/provider/collection/data.csv",
         }
 
         s3 = botocore.session.get_session().create_client("s3")


### PR DESCRIPTION
Closes #209 

This adds a validation task that compares the current and prior harvest. Ending the pipeline if the data has not changed.

If there are no differences between the current and previous harvest, the ETL pipeline will be skipped:
![Screen Shot 2022-09-20 at 3 26 01 PM](https://user-images.githubusercontent.com/2294288/191378830-f9e09c3c-00b6-4bcb-85e3-197d4de09a27.png)

If any differences are detected the ETL pipeline will be started:
![Screen Shot 2022-09-20 at 3 52 27 PM](https://user-images.githubusercontent.com/2294288/191378834-6310bd8c-4fb3-4935-b532-37207341e591.png)

Note: this adds a SKIP_HARVEST_VALIDATION env var to docker compose to avoid including this step during local development. At this time, this interacts directly with S3, so only has access to the S3 bucket when deployed to AWS.