### PR TITLE
Handle 404 errors in IiifJsonSource

### DIFF
--- a/tests/drivers/test_iiif_json.py
+++ b/tests/drivers/test_iiif_json.py
@@ -9,6 +9,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 class MockIIIFCollectionResponse:
+    @property
+    def status_code(self):
+        return 200
+
     @staticmethod
     def json():
         return {
@@ -19,6 +23,10 @@ class MockIIIFCollectionResponse:
 
 
 class MockIIIFManifestResponse:
+    @property
+    def status_code(self):
+        return 200
+
     @staticmethod
     def json():
         return {


### PR DESCRIPTION
The princeton/manuscripts harvest was failing because one of the manifest URLs was a 404. This change adds a skip behavior for any manifests that don't return a 200 OK. Any manifests that fail to load are logged:

```
2022-09-21 15:36:21,552 - ERROR - got 404 when fetching manifest https://figgy.princeton.edu/concern/scanned_resources/e6977a4b-edd4-4aa6-bcb0-c605a82d2721/manifest
```

Closes #251
