### PR TITLE
Refactor models for easier testing instantiation

### DIFF
--- a/dlme_airflow/models/collection.py
+++ b/dlme_airflow/models/collection.py
@@ -5,7 +5,10 @@ class Collection(object):
     def __init__(self, provider, collection):
         self.name = collection
         self.provider = provider
-        self.catalog = catalog_for_provider(f"{provider.name}.{self.name}")
+
+    @property
+    def catalog(self):
+        return catalog_for_provider(f"{self.provider.name}.{self.name}")
 
     def label(self):
         return f"{self.provider.name}_{self.name}"

--- a/dlme_airflow/models/provider.py
+++ b/dlme_airflow/models/provider.py
@@ -5,8 +5,22 @@ from dlme_airflow.models.collection import Collection
 class Provider(object):
     def __init__(self, catalog):
         self.name = catalog
-        self.catalog = catalog_for_provider(catalog)
-        self.collections = self.__collections_for()
+
+    @property
+    def catalog(self):
+        return catalog_for_provider(self.name)
+
+    @property
+    def collections(self):
+        _collections = []
+        try:
+            provider_collections = iter(list(self.catalog))
+            for provider_collection in provider_collections:
+                _collections.append(Collection(self, provider_collection))
+        except TypeError as err:
+            print(f"ERROR Parsing collections for provider {self.name}: {err}")
+
+        return _collections
 
     def get_collection(self, collection_name):
         for coll in self.collections:
@@ -19,14 +33,3 @@ class Provider(object):
 
     def data_path(self):
         return self.catalog.metadata.get("data_path", self.name)
-
-    def __collections_for(self):
-        collections = []
-        try:
-            provider_collections = iter(list(self.catalog))
-            for provider_collection in provider_collections:
-                collections.append(Collection(self, provider_collection))
-        except TypeError as err:
-            print(f"ERROR Parsing collections for provider {self.name}: {err}")
-
-        return collections

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,6 +55,7 @@ x-airflow-common:
     AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
     AIRFLOW__CORE__FERNET_KEY: ''
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
+    AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90
     AIRFLOW__CORE__LOAD_EXAMPLES: 'false' # do not load example DAGs
     AIRFLOW__CORE__DAGS_FOLDER: '/opt/airflow/dlme_airflow/dags'
     AIRFLOW__CORE__DEFAULT_TIMEZONE: 'America/Los_Angeles'

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -18,6 +18,6 @@ def test_Collection():
 def test_Provider_NotFound():
     with pytest.raises(ValueError) as error:
         provider = Provider("aub")
-        Collection(provider, "amc")
+        Collection(provider, "amc").catalog
 
     assert str(error.value) == "Provider (aub.amc) not found in catalog"

--- a/tests/models/test_provider.py
+++ b/tests/models/test_provider.py
@@ -12,6 +12,6 @@ def test_Provider():
 
 def test_Provider_NotFound():
     with pytest.raises(ValueError) as error:
-        Provider("does_not_exist")
+        Provider("does_not_exist").catalog
 
     assert str(error.value) == "Provider (does_not_exist) not found in catalog"


### PR DESCRIPTION
This follows a comment by @edsu when establishing these models to move the catalog methods into decorated properties to allow for instantiation of mocks for easier use in testing.