### PR TITLE
Update the circleci python orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@2.0.3
+  python: circleci/python@2.1.1
 
 executors:
   docker-publisher:


### PR DESCRIPTION
Looks like the 2.0.3 orb is no longer valid, 2.1.1 was updated a few days ago.