### PR TITLE
Setting up catalog validation

### DIFF
--- a/tests/catalogs/test_catalogs.py
+++ b/tests/catalogs/test_catalogs.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from jsonschema import validate
+import pytest
+import yaml
+
+
+@pytest.fixture
+def validate_schema(load_schema, load_catalog):
+    def assert_valid_schema(catalog_file, schema_file):
+        """Checks whether the given catalog matches the schema"""
+        schema = load_schema(schema_file)
+        catalog = load_catalog(catalog_file)
+        return validate(catalog, schema)
+
+    return assert_valid_schema
+
+
+@pytest.fixture
+def load_schema():
+    def load_yaml_schema(filename):
+        """Loads the given schema file"""
+        schema_path = Path.cwd().joinpath("tests", "support", "schemas", filename)
+        with open(schema_path) as schema_file:
+            return yaml.safe_load(schema_file.read())
+
+    return load_yaml_schema
+
+
+@pytest.fixture
+def load_catalog():
+    def load_catalog_file(filename):
+        """Load the catalog file"""
+        catalog_path = Path.cwd().joinpath("catalogs", filename)
+        with open(catalog_path) as catalog_file:
+            return yaml.safe_load(catalog_file.read())
+
+    return load_catalog_file
+
+
+def test_validate_catalogs(validate_schema):
+    schema = "schema.yaml"
+    for catalog in Path.cwd().joinpath("catalogs").iterdir():
+        if catalog.name != "catalog.yaml":
+            validate_schema(catalog, schema)

--- a/tests/support/schemas/schema.yaml
+++ b/tests/support/schemas/schema.yaml
@@ -1,0 +1,65 @@
+
+properties:
+  metadata:
+    description: Provider metadata
+    type: object
+    properties:
+      version:
+        type: integer
+      data_path:
+        description: Directory for data
+        type: string
+      schedule:
+        type: string
+    required: [data_path]
+  sources:
+    description: Collections from a provider
+    type: object
+    additionalProperties: # since each source has an arbitrary key
+      properties:
+        driver:
+          description: Driver for airflow
+          type: string
+          enum:
+            - csv
+            - custom_json
+            - iiif_json
+            - oai_xml
+            - sequential_csv
+            - xml
+        metadata:
+          type: object
+          properties:
+            data_path:
+              type: string
+            config:
+              description: name of traject_config in dlme-transform
+              type: string
+          required: [data_path, config]
+      required: [metadata, driver]
+      allOf:
+        - if: 
+            properties:
+              driver: 
+                const: oai_xml
+          then:
+            properties:
+              args:
+                type: object
+                properties:
+                  metadata_prefix:
+                    type: string
+                required: [metadata_prefix]
+        - if:
+            properties:
+              driver: 
+                const: custom_json
+          then:
+            properties:
+              metadata:
+                type: object
+                properties:
+                  record_selector:
+                    type: string
+                required: [record_selector]
+required: [metadata, sources]


### PR DESCRIPTION
Some questions on this draft PR: 

1. I think we can just use one schema for all the catalogs (see the `allOf` section that has some logic based on the driver). Where should the `schema.yaml` best live?
2. What are the other validations we want to add?
3. We can add description of each field, but I don't know enough yet about the fields to provide those. 