### PR TITLE
Fix bin/get --limit

### DIFF
--- a/dlme_airflow/models/collection.py
+++ b/dlme_airflow/models/collection.py
@@ -5,10 +5,7 @@ class Collection(object):
     def __init__(self, provider, collection):
         self.name = collection
         self.provider = provider
-
-    @property
-    def catalog(self):
-        return catalog_for_provider(f"{self.provider.name}.{self.name}")
+        self.catalog = catalog_for_provider(f"{self.provider.name}.{self.name}")
 
     def label(self):
         return f"{self.provider.name}_{self.name}"

--- a/dlme_airflow/models/provider.py
+++ b/dlme_airflow/models/provider.py
@@ -5,10 +5,7 @@ from dlme_airflow.models.collection import Collection
 class Provider(object):
     def __init__(self, catalog):
         self.name = catalog
-
-    @property
-    def catalog(self):
-        return catalog_for_provider(self.name)
+        self.catalog = catalog_for_provider(self.name)
 
     @property
     def collections(self):


### PR DESCRIPTION
In 38df69fcbb5bfc2e33375db3babb723ffe478840 we stopped instantiating one catalog per Collection and Provider in the constructor and instantiate a new one each time the `catalog` property is used. This means that you can't actually modify the one that will get used by intake. This isn't usually an issue except for the `bin/get` utility with tries to set `.record_limit` after the fact, but prior to running the harvest.
