### PR TITLE
Fix a small bug in collections that make long data_paths problematic …

### DIFF
--- a/dlme_airflow/models/collection.py
+++ b/dlme_airflow/models/collection.py
@@ -14,4 +14,5 @@ class Collection(object):
         return self.catalog.metadata.get("data_path")
 
     def intermidiate_representation_location(self):
-        return f"https://dlme-metadata-dev.s3.us-west-2.amazonaws.com/output/output-{self.data_path()}.ndjson"
+        normalized_data_path = self.data_path().replace("/", "-")
+        return f"https://dlme-metadata-dev.s3.us-west-2.amazonaws.com/output/output-{normalized_data_path}.ndjson"

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -11,7 +11,7 @@ def test_Collection():
     assert collection.data_path() == "aub/aco"
     assert (
         collection.intermidiate_representation_location()
-        == "https://dlme-metadata-dev.s3.us-west-2.amazonaws.com/output/output-aub/aco.ndjson"
+        == "https://dlme-metadata-dev.s3.us-west-2.amazonaws.com/output/output-aub-aco.ndjson"
     )
 
 


### PR DESCRIPTION
…for reporting

Some reports are failing because the data_path is `provider/iiif/collection` which is currently output here as:

.../output-provider/iiif/collection.ndjson when the path is really ..../output-provider-iiif-collection.ndjson