### PR TITLE
AUB Campus Photos uses the OAI driver

### DIFF
--- a/catalogs/auc.yaml
+++ b/catalogs/auc.yaml
@@ -161,7 +161,7 @@ sources:
       metadata_prefix: oai_dc
       set: p15795coll32
     metadata:
-      data_path: auc/iiif/campus_photos
+      data_path: auc/oai/campus_photos
       config: auc_oai_config
       schedule: "40 2 * * *"
       fields:


### PR DESCRIPTION
The data_path should be `oai` instead of `iiif` for the campus_photos collection in order to properly transform the data (the configuration uses is based on this path: https://github.com/sul-dlss/dlme-transform/blob/main/config/metadata_mapping.json#L223)