### PR TITLE
Remove blank lines when reading the IR for report

### DIFF
--- a/dlme_airflow/task_groups/validate_dlme_metadata.py
+++ b/dlme_airflow/task_groups/validate_dlme_metadata.py
@@ -13,8 +13,7 @@ from airflow.utils.task_group import TaskGroup
 dev_role_arn = os.getenv("DEV_ROLE_ARN")
 
 home_directory = os.getenv("AIRFLOW_HOME", "/opt/airflow")
-metadata_directory = f"{home_directory}/metadata/"
-working_directory = f"{home_directory}/working/"
+working_directory = f"{home_directory}/metadata"
 s3_data = os.getenv("S3_BUCKET")
 
 
@@ -55,7 +54,7 @@ def build_sync_metadata_taskgroup(collection, dag: DAG) -> TaskGroup:
         export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs) && \
         export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs) && \
         export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs) && \
-        aws s3 sync {working_directory}/{collection.data_path()} {s3_data}/{collection.data_path()} --delete
+        aws s3 sync {working_directory}/{collection.data_path()} {s3_data}/metadata/{collection.data_path()} --delete
         """
         aws_assume_role = BashOperator(
             task_id="assume_role",
@@ -64,7 +63,7 @@ def build_sync_metadata_taskgroup(collection, dag: DAG) -> TaskGroup:
             dag=dag,
         )
 
-        bash_sync_s3 = f"aws s3 sync {working_directory}/{collection.data_path()} {s3_data}/{collection.data_path()} --delete"
+        bash_sync_s3 = f"aws s3 sync {working_directory}/{collection.data_path()} {s3_data}/metadata/{collection.data_path()} --delete"
         sync_metadata = BashOperator(
             task_id="sync_metadata",
             bash_command=bash_sync_s3,

--- a/dlme_airflow/tasks/harvest_report.py
+++ b/dlme_airflow/tasks/harvest_report.py
@@ -185,7 +185,7 @@ def main(**kwargs):  # input:, config:):
     open(input_file, "wb").write(r.content)
 
     with open(input_file, "r") as file:
-        records = file.readlines()
+        records = [line for line in file.readlines() if line.strip()]
         provider = json.loads(records[0])["agg_data_provider"]["en"][0]
         collection = json.loads(records[0])["agg_data_provider_collection"]["en"][0]
         record_count = len(records)

--- a/dlme_airflow/utils/dataframe.py
+++ b/dlme_airflow/utils/dataframe.py
@@ -14,7 +14,7 @@ def dataframe_from_s3(collection) -> pd.DataFrame:
     # TODO: This needs to take creds. See: https://stackoverflow.com/a/45982080/7600626
     #    -- see how to make this work with localstack so we don't have to hammer S3 for local dev.
     s3 = boto3.client("s3")
-    bucket = os.getenv("S3_BUCKET")
+    bucket = os.getenv("S3_BUCKET").replace("s3://", "")
     key = f"metadata/{data_path}/data.csv"
     obj = s3.get_object(Bucket=bucket, Key=key)
     return pd.read_csv(obj["Body"])


### PR DESCRIPTION
This is a small bug fix that is caused especially if the first line of the IR is blank since the provider and collection data is fetched from the first record. This removes all blank lines as the file is read.

Confirmed that this resolves the boldeian turkish collection report failure (and likely others)