### PR TITLE
Fix s3 and catalog bug

### DIFF
--- a/catalogs/american_numismatic_society.yaml
+++ b/catalogs/american_numismatic_society.yaml
@@ -1,6 +1,7 @@
 metadata:
   version: 1
   schedule: "20 0 * * *"
+  data_path: "american_numismatic_society"
 sources:
   american_numismatic_society:
     description: American Numismatic Society

--- a/dlme_airflow/task_groups/validate_dlme_metadata.py
+++ b/dlme_airflow/task_groups/validate_dlme_metadata.py
@@ -13,9 +13,8 @@ from airflow.utils.task_group import TaskGroup
 dev_role_arn = os.getenv("DEV_ROLE_ARN")
 
 home_directory = os.getenv("AIRFLOW_HOME", "/opt/airflow")
-metadata_directory = f"{home_directory}/metadata/"
-working_directory = f"{home_directory}/working/"
-s3_data = os.getenv("S3_BUCKET")
+working_directory = f"{home_directory}/metadata"
+s3_data = f"s3://{os.getenv('S3_BUCKET')}/metadata"
 
 
 def require_credentials(**kwargs):


### PR DESCRIPTION
A couple of small bug fixes.

- We need the same `S3_BUCKET` values in datafrom_from_s3 and `sync_data` however the former can't have the `s3://` prefix while the latter needs it.
- Sets the data path on ANS to fix the main build.

Verified locally this fixes the `assume_role` failure.