### PR TITLE
catalog config yaml linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,17 @@ jobs:
       - python/install-packages:
           pkg-manager: poetry
       - run:
-          name: Lint with flake8
+          name: Lint the code with flake8
           command: |
              poetry run flake8
       - run:
-          name: Lint with Black
+          name: Lint the code with Black
           command: |
              poetry run black --diff --check .
+      - run:
+          name: Lint the Intake catalog configs with yamllint
+          command: |
+             poetry run yamllint catalogs/
 
   typechecking:
     executor:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  document-start:
+    present: false
+  line-length: disable

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ To assist in passing the linter, use the [Black][BLK] opinionated code formatter
 by running `black dlme_airflow/path/to/file.py` (this will immediately apply the
 formatting it would suggest).
 
+To help keep Intake catalog configs consistent in terms of basic style and formatting, we're using [yamllint][YAMLLINT].
+To lint all of the configs, run `yamllint catalogs/`.  If you want to lint individual files, run e.g. `yamllint file1.yaml path/file2.yml`.
+Note that if `yamllint` produces warnings but no errors, it'll return an exit code of 0, allowing the build to pass. If
+it detects errors, it'll return an exit code of 1 and fail the build.
+
 ## Typechecking
 We're using [mypy][MYPY] for type checking.  Type checking is opt-in, so you shouldn't have to specify
 types for new code, and unknown types from dependencies will be ignored (via project configuration).  But if
@@ -142,6 +147,7 @@ You can also run individual tests with `PYTHONPATH=dlme_airflow pytest tests/pat
 poetry run black --diff --check . &&
   poetry run mypy . &&
   poetry run flake8 &&
+  poetry run yamllint catalogs/ &&
   PYTHONPATH=dlme_airflow poetry run pytest -s --pdb
 ```
 * run black first because it's fast; remove the flags to just apply formatting
@@ -260,3 +266,4 @@ $ bin/get yale babylonian --limit 20
 [Spotlight]: https://github.com/projectblacklight/spotlight
 [ETL]: https://en.wikipedia.org/wiki/Extract,_transform,_load
 [MYPY]: https://mypy.readthedocs.io/
+[YAMLLINT]: https://yamllint.readthedocs.io/en/stable/index.html

--- a/catalogs/aub.yaml
+++ b/catalogs/aub.yaml
@@ -17,7 +17,7 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true
   aladab:
     driver: oai_xml
     args:
@@ -32,7 +32,7 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true
   postcards:
     driver: oai_xml
     args:
@@ -47,7 +47,7 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true
   posters:
     driver: oai_xml
     args:
@@ -62,7 +62,7 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true
   travelbooks:
     driver: oai_xml
     args:
@@ -77,4 +77,4 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true

--- a/catalogs/csic.yaml
+++ b/catalogs/csic.yaml
@@ -17,4 +17,4 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true

--- a/catalogs/dasi.yaml
+++ b/catalogs/dasi.yaml
@@ -17,4 +17,4 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true

--- a/catalogs/harvard.yaml
+++ b/catalogs/harvard.yaml
@@ -17,7 +17,7 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true
   scw:
     description: "Stuart Cary Welsch Collection"
     driver: xml

--- a/catalogs/ifpo.yaml
+++ b/catalogs/ifpo.yaml
@@ -17,58 +17,58 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true
         description_ar:
           path: "//*/dc:description[@xml:lang='ar']"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
             dc: "http://purl.org/dc/elements/1.1/"
-          optional: True
+          optional: true
         description_en:
           path: "//*/dc:description[@xml:lang='en']"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
             dc: "http://purl.org/dc/elements/1.1/"
-          optional: True
+          optional: true
         description_fr:
           path: "//*/dc:description[@xml:lang='fr']"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
             dc: "http://purl.org/dc/elements/1.1/"
-          optional: True
+          optional: true
         subject_ar:
           path: "//*/dc:subject[@xml:lang='ar']"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
             dc: "http://purl.org/dc/elements/1.1/"
-          optional: True
+          optional: true
         subject_en:
           path: "//*/dc:subject[@xml:lang='en']"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
             dc: "http://purl.org/dc/elements/1.1/"
-          optional: True
+          optional: true
         subject_fr:
           path: "//*/dc:subject[@xml:lang='fr']"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
             dc: "http://purl.org/dc/elements/1.1/"
-          optional: True
+          optional: true
         title_ar:
           path: "//*/dc:title[@xml:lang='ar']"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
             dc: "http://purl.org/dc/elements/1.1/"
-          optional: True
+          optional: true
         title_en:
           path: "//*/dc:title[@xml:lang='en']"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
             dc: "http://purl.org/dc/elements/1.1/"
-          optional: True
+          optional: true
         title_fr:
           path: "//*/dc:title[@xml:lang='fr']"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
             dc: "http://purl.org/dc/elements/1.1/"
-          optional: True
+          optional: true

--- a/catalogs/manchester.yaml
+++ b/catalogs/manchester.yaml
@@ -17,4 +17,4 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true

--- a/catalogs/qnl.yaml
+++ b/catalogs/qnl.yaml
@@ -19,4 +19,4 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true

--- a/catalogs/texas_tech.yaml
+++ b/catalogs/texas_tech.yaml
@@ -17,4 +17,4 @@ sources:
           path: "//header:identifier"
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
-          optional: True
+          optional: true

--- a/poetry.lock
+++ b/poetry.lock
@@ -466,14 +466,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "boto3"
-version = "1.24.82"
+version = "1.24.83"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = ">=1.27.82,<1.28.0"
+botocore = ">=1.27.83,<1.28.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -482,7 +482,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.27.82"
+version = "1.27.83"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -2019,14 +2019,14 @@ test = ["pytest"]
 
 [[package]]
 name = "setuptools"
-version = "65.4.0"
+version = "65.4.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
@@ -2373,6 +2373,19 @@ ipaddress = ["ipaddress"]
 locale = ["Babel (>=1.3)"]
 
 [[package]]
+name = "yamllint"
+version = "1.28.0"
+description = "A linter for YAML files."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pathspec = ">=0.5.3"
+pyyaml = "*"
+setuptools = "*"
+
+[[package]]
 name = "yarl"
 version = "1.8.1"
 description = "Yet another URL library"
@@ -2399,7 +2412,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "52b3bbf2dcf94263773087fe058f1506364a23d3d23f7d4a7c54dd055d097b66"
+content-hash = "e10a057dc1203e09bffeae39041473be0eaac015db0f40f6a5b4f3d4ed0be8bd"
 
 [metadata.files]
 aiohttp = [
@@ -2593,12 +2606,12 @@ blinker = [
     {file = "blinker-1.5.tar.gz", hash = "sha256:923e5e2f69c155f2cc42dafbbd70e16e3fde24d2d4aa2ab72fbe386238892462"},
 ]
 boto3 = [
-    {file = "boto3-1.24.82-py3-none-any.whl", hash = "sha256:90d590eda672775ef5ad0cdd4f5c2a51a964e3de631f3deccbc96e29cf0cd5a9"},
-    {file = "boto3-1.24.82.tar.gz", hash = "sha256:2a9b283cd4208cfcea873baac29e5ceb011afbd5a5c5b7a35cb305f377c39f60"},
+    {file = "boto3-1.24.83-py3-none-any.whl", hash = "sha256:a29214908224da132ecc025f4da266f4124c26d22205002bfd02aed5743a2e47"},
+    {file = "boto3-1.24.83.tar.gz", hash = "sha256:b10d9ecaba3f0ed844192828d2c2b26bfa1dfd2b40ccccc25507575f28097e32"},
 ]
 botocore = [
-    {file = "botocore-1.27.82-py3-none-any.whl", hash = "sha256:034cdcfb74bcca9124fcaafed857ad78ec572ff95ed802b0608fa7505aaf4a1f"},
-    {file = "botocore-1.27.82.tar.gz", hash = "sha256:b122c7048a79fef53f3d45f7ca2999c2559e15fc4531653824ebd3154d77ede5"},
+    {file = "botocore-1.27.83-py3-none-any.whl", hash = "sha256:9a1fb823c68aef1227f2d63af856a485e09f43792f257a821b53ea86481c66bd"},
+    {file = "botocore-1.27.83.tar.gz", hash = "sha256:c57f74322cf672405f0ec7ee8fda7d80d323a9c664a90926c11313ca3bfbca91"},
 ]
 cachelib = [
     {file = "cachelib-0.9.0-py3-none-any.whl", hash = "sha256:811ceeb1209d2fe51cd2b62810bd1eccf70feba5c52641532498be5c675493b3"},
@@ -3827,8 +3840,8 @@ setproctitle = [
     {file = "setproctitle-1.3.2.tar.gz", hash = "sha256:b9fb97907c830d260fa0658ed58afd48a86b2b88aac521135c352ff7fd3477fd"},
 ]
 setuptools = [
-    {file = "setuptools-65.4.0-py3-none-any.whl", hash = "sha256:c2d2709550f15aab6c9110196ea312f468f41cd546bceb24127a1be6fdcaeeb1"},
-    {file = "setuptools-65.4.0.tar.gz", hash = "sha256:a8f6e213b4b0661f590ccf40de95d28a177cd747d098624ad3f69c40287297e9"},
+    {file = "setuptools-65.4.1-py3-none-any.whl", hash = "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012"},
+    {file = "setuptools-65.4.1.tar.gz", hash = "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"},
 ]
 sgmllib3k = [
     {file = "sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9"},
@@ -4048,6 +4061,9 @@ wrapt = [
 WTForms = [
     {file = "WTForms-2.3.3-py2.py3-none-any.whl", hash = "sha256:7b504fc724d0d1d4d5d5c114e778ec88c37ea53144683e084215eed5155ada4c"},
     {file = "WTForms-2.3.3.tar.gz", hash = "sha256:81195de0ac94fbc8368abbaf9197b88c4f3ffd6c2719b5bf5fc9da744f3d829c"},
+]
+yamllint = [
+    {file = "yamllint-1.28.0.tar.gz", hash = "sha256:9e3d8ddd16d0583214c5fdffe806c9344086721f107435f68bad990e5a88826b"},
 ]
 yarl = [
     {file = "yarl-1.8.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:abc06b97407868ef38f3d172762f4069323de52f2b70d133d096a48d72215d28"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ jsonschema = "^4.16.0"
 requests-mock = "^1.10.0"
 mock = "^4.0.3"
 types-mock = "^4.0.15"
+yamllint = "^1.28.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
* add YAML linting for Intake catalog configs
* normalize catalog configs on `true` and `false` for boolean values (gets rid of warnings from yamllint for the [`truthy`](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy) rule)
  * if you look at the CircleCI logs for the first commit, you can see [an example of yamllint's warnings in CI](https://app.circleci.com/pipelines/github/sul-dlss/dlme-airflow/674/workflows/9a913c30-4cbc-4fc1-9f65-a771574b5101/jobs/1801?invite=true#step-113-4)

connects with #132 