### PR TITLE
Add Cambridge images

### DIFF
--- a/catalogs/cambridge.yaml
+++ b/catalogs/cambridge.yaml
@@ -17,6 +17,8 @@ sources:
           path: "@id"
         description:
           path: "description"
+        thumbnail:
+          path: "sequences[0].canvases[0].images[0].resource.@id"
   hebrew:
     description: "Items of Hebrew origin"
     driver: iiif_json
@@ -31,6 +33,8 @@ sources:
           path: "@id"
         description:
           path: "description"
+        thumbnail:
+          path: "sequences[0].canvases[0].images[0].resource.@id"
   islamic:
     description: "Islamic manuscripts"
     driver: iiif_json
@@ -45,3 +49,6 @@ sources:
           path: "@id"
         description:
           path: "description"
+        thumbnail:
+          path: "sequences[0].canvases[0].images[0].resource.@id"
+


### PR DESCRIPTION
I'm not sure that the thumbnails are available via these manifiests, but here is a configuration to get the first JP2.

```
bin/get cambridge genizah --limit 5 | xsv select thumbnail
thumbnail
https://images.lib.cam.ac.uk/iiif/MS-ADD-02586-000-00001.jp2
https://images.lib.cam.ac.uk/iiif/MS-ADD-03335-000-00001.jp2
https://images.lib.cam.ac.uk/iiif/MS-ADD-03336-000-00001.jp2
https://images.lib.cam.ac.uk/iiif/MS-ADD-03337-000-00001.jp2
https://images.lib.cam.ac.uk/iiif/MS-ADD-03340-000-00001.jp2
```

Closes #288
