### PR TITLE
Account for language tagged values in IIIF manifests

### DIFF
--- a/dlme_airflow/drivers/iiif_json.py
+++ b/dlme_airflow/drivers/iiif_json.py
@@ -91,10 +91,14 @@ class IiifJsonSource(intake.source.base.DataSource):
                 .replace(")", "")
             )
             # initialize or append to output[name] based on whether we've seen the label
+            metadata_value = row.get("value")
+            if isinstance(metadata_value[0], dict):
+                metadata_value = metadata_value[0].get("@value")
+
             if name in output:
-                output[name].append(row.get("value"))
+                output[name].append(metadata_value)
             else:
-                output[name] = [row.get("value")]
+                output[name] = [metadata_value]
         return output
 
     def _get_partition(self, i) -> pd.DataFrame:


### PR DESCRIPTION
Fixes #283 

Princeton is providing language tagged IIIF, something like:
```
"metadata": [
    {
      "label": "Director",
      "value": [
        {
          "@language": "ara-arab",
          "@value": "محمود فريد"
        }
      ]
    },
    {
      "label": "Date Created",
      "value": [
        "1974"
      ]
    }
]
```

Notice the first `value` is a hash with `@language` and `@value`, and the second entry the `value` is a simple string. Currently we output `value`, so for the first we're getting the hash when we want the `value..@value` string. 

A test transform looks like;
```
{"cho_title":{"und-Arab":["عريس الهناء"]},"cho_contributor":{"ar-Arab":["Director: محمود فريد"],"und-Arab":["Actor: محمد عوض"]},"cho_date":{"en":["1974"]},"cho_date_range_norm":[1974],"cho_date_range_hijri":[1393,1394],"cho_dc_rights":{"en":["https://rbsc.princeton.edu/services/imaging-publication-services"]},"cho_edm_type":{"en":["Text"],"ar-Arab":["نص"]},"cho_extent":{"en":["1 piece."]},"cho_has_type":{"en":["Manuscripts"],"ar-Arab":["المخطوطات"]},"cho_identifier":["ark:/88435/qb98mg822","eg1-0943"],"cho_is_part_of":{"en":["Middle Eastern Film Posters Digitization Initiative","Selections from the Near East Collections"]},"cho_language":{"en":["Arabic"],"ar-Arab":["العربية"]},"cho_spatial":{"en":["Egypt"]},"cho_subject":{"en":["Posters"]},"cho_type":{"en":["[['still image']]"]},"agg_data_provider":{"en":["Princeton University Library"],"ar-Arab":["مكتبة جامعة برينستون"]},"agg_data_provider_country":{"en":["United States of America"],"ar-Arab":["الولايات المتحدة الامريكيه"]},"agg_provider":{"en":["Princeton University Library"],"ar-Arab":["مكتبة جامعة برينستون"]},"agg_provider_country":{"en":["United States of America"],"ar-Arab":["الولايات المتحدة الامريكيه"]},"cho_type_facet":{"en":["Text","Text:Manuscripts"],"ar-Arab":["نص","نص:المخطوطات"]},"id":"ark:/88435/qb98mg822","agg_data_provider_collection_id":"princeton-movie-posters","agg_is_shown_at":{"wr_is_referenced_by":["https://figgy.princeton.edu/concern/scanned_resources/54adbfe8-cf1e-44a3-8808-f1cba908b51b/manifest"],"wr_id":"ark:/88435/qb98mg822"},"agg_preview":{"wr_is_referenced_by":["https://figgy.princeton.edu/concern/scanned_resources/54adbfe8-cf1e-44a3-8808-f1cba908b51b/manifest"],"wr_id":"https://iiif-cloud.princeton.edu/iiif/2/41%2F0c%2F51%2F410c517e2404430994da59ce740655f0%2Fintermediate_file/full/!400,400/0/default.jpg"}}
```
Notice that the `Director` value is not a language tagged hash.