### PR TITLE
add qnl and harvard ihp

### DIFF
--- a/catalogs/harvard.yaml
+++ b/catalogs/harvard.yaml
@@ -7,7 +7,7 @@ sources:
     driver: oai_xml
     args:
       collection_url: https://api.lib.harvard.edu/oai
-      metadata_prefix: oai_dc
+      metadata_prefix: mods
       set: "ihp"
     metadata:
       data_path: harvard/islamic_heritage_project
@@ -18,63 +18,8 @@ sources:
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
           optional: true
-        title:
-          path: ".//mods:titleInfo/mods:title"
-          namespace:
-            mods: "http://www.loc.gov/mods/v3"
-          optional: true
-        type:
-          path: ".//mods:typeOfResource"
-          namespace:
-            mods: "http://www.loc.gov/mods/v3"
-          optional: false
-        genre:
-          path: ".//mods:genre"
-          namespace:
-            mods: "http://www.loc.gov/mods/v3"
-          optional: false
-        place:
-          path: ".//mods:originInfo/mods:place/mods:placeTerm"
-          namespace:
-            mods: "http://www.loc.gov/mods/v3"
-          optional: false
-        publisher:
-          path: ".//mods:originInfo/mods:place/mods:publisher"
-          namespace:
-            mods: "http://www.loc.gov/mods/v3"
-          optional: false
-        date_issued:
-          path: ".//mods:originInfo/mods:dateIssued"
-          namespace:
-            mods: "http://www.loc.gov/mods/v3"
-          optional: false
-        physical_description:
-          path: ".//mods:physicalDescription/mods:extent"
-          namespace:
-            mods: "http://www.loc.gov/mods/v3"
-          optional: false
-        subject:
-          path: ".//mods:subject/mods:topic"
-          namespace:
-            mods: "http://www.loc.gov/mods/v3"
-          optional: false
-        physical_location:
-          path: ".//mods:location/mods:physicalLocation"
-          namespace:
-            mods: "http://www.loc.gov/mods/v3"
-          optional: false
-        shelf_locator:
-          path: ".//mods:location/mods:shelfLocator"
-          namespace:
-            mods: "http://www.loc.gov/mods/v3"
-          optional: false
-        record_identifier:
-          path: ".//mods:recordInfo/mods:recordIdentifier"
-          namespace:
-            mods: "http://www.loc.gov/mods/v3"
-          optional: false
-        language:
-          path: ".//mods:language/mods:languageTerm[@type = 'code']"
+        personal_name:
+          path: "//mods:name[@type = 'personal']/mods:namePart[not(@type = 'date')]"
           namespace:
             mods: "http://www.loc.gov/mods/v3"
           optional: false
@@ -88,8 +33,18 @@ sources:
           namespace:
             mods: "http://www.loc.gov/mods/v3"
           optional: false
-        is_shown:
+        raw_object:
           path: ".//mods:location/mods:url[@access = 'raw object']"
+          namespace:
+            mods: "http://www.loc.gov/mods/v3"
+          optional: false
+        title_alternative:
+          path: "//mods:titleInfo[@type = 'alternative']/mods:title"
+          namespace:
+            mods: "http://www.loc.gov/mods/v3"
+          optional: false
+        title:
+          path: "//mods:titleInfo[not(ancestor::mods:relatedItem)]/mods:title"
           namespace:
             mods: "http://www.loc.gov/mods/v3"
           optional: false

--- a/catalogs/qnl.yaml
+++ b/catalogs/qnl.yaml
@@ -21,3 +21,28 @@ sources:
           namespace:
             header: "http://www.openarchives.org/OAI/2.0/"
           optional: true
+        author:
+          path: "//mods:namePart[../mods:role/mods:roleTerm='author']"
+          namespace:
+            mods: "http://www.loc.gov/mods/v3"
+          optional: false
+        shown_at:
+          path: ".//mods:location/mods:url[not(@access = 'preview')]"
+          namespace:
+            mods: "http://www.loc.gov/mods/v3"
+          optional: false
+        preview:
+          path: ".//mods:location/mods:url[@access = 'preview']"
+          namespace:
+            mods: "http://www.loc.gov/mods/v3"
+          optional: false
+        title_alternative:
+          path: "//mods:titleInfo[@type = 'alternative']/mods:title"
+          namespace:
+            mods: "http://www.loc.gov/mods/v3"
+          optional: false
+        title:
+          path: "//mods:titleInfo[not(ancestor::mods:relatedItem)]/mods:title"
+          namespace:
+            mods: "http://www.loc.gov/mods/v3"
+          optional: false

--- a/dlme_airflow/utils/qnl.py
+++ b/dlme_airflow/utils/qnl.py
@@ -11,6 +11,7 @@ def merge_records(**kwargs):
     df = pd.read_csv(working_csv)
 
     # merge rows with the same shelf locator
-    df_merged = df.groupby("location_shelfLocator").agg(lambda x: x.tolist())
+    df_filled = df.fillna("NOT PROVIDED")
+    df_merged = df_filled.groupby("location_shelfLocator").agg(lambda x: x.tolist())
 
     df_merged.to_csv(working_csv)


### PR DESCRIPTION
- Adds QNL and Harvard IHP
- QNL post harvest task was writing 'nan' strings to csv output. I couldn't figure out how to not do that, so instead I wrote 'NOT PROVIDED' and then remove this value in traject
- Once we have a full harvest of QNL, I will need to revise this to make sure we are getting all role values (this only gets 'author', but I don't know what other roles to look for)