### PR TITLE
Remove halving of ndjson count bug

### DIFF
--- a/dlme_airflow/tasks/transform_validation.py
+++ b/dlme_airflow/tasks/transform_validation.py
@@ -26,9 +26,7 @@ def _get_transformed_record_count(collection) -> int:
         records = file.readlines()
         transformed_record_count = len(records)
 
-    # TODO: row_count is halved here to work around a current bug in the dlme-transform code.
-    # get rid of halving once https://github.com/sul-dlss/dlme-transform/issues/931 is resolved.
-    return int(transformed_record_count / 2)
+    return int(transformed_record_count)
 
 
 def validate_transformation(task_instance, **kwargs):

--- a/tests/tasks/test_transform_validation.py
+++ b/tests/tasks/test_transform_validation.py
@@ -20,9 +20,7 @@ class MockTaskInstance:
 
 
 def mock_ndjson_response_text(row_count) -> str:
-    # TODO: row_count is doubled here to simulate a current bug in the dlme-transform code.
-    # get rid of doubling once https://github.com/sul-dlss/dlme-transform/issues/931 is resolved.
-    json_rows = [json.dumps({"row_num": i}) for i in range(row_count * 2)]
+    json_rows = [json.dumps({"row_num": i}) for i in range(row_count)]
     return "\n".join(json_rows)
 
 


### PR DESCRIPTION
We original observed a bug when running locally that indicated duplication of records in the ndjson output, however, we are not seeing that bug in the AWS deployment.