### PR TITLE
[DRAFT] Add optional provider_email to send harvest report task

### DIFF
--- a/dlme_airflow/models/provider.py
+++ b/dlme_airflow/models/provider.py
@@ -19,6 +19,10 @@ class Provider(object):
 
         return _collections
 
+    @property
+    def email(self):
+        return self.catalog.metadata.get("provider_email", "")
+
     def get_collection(self, collection_name):
         for coll in self.collections:
             if coll.name == collection_name:

--- a/tests/support/schemas/schema.yaml
+++ b/tests/support/schemas/schema.yaml
@@ -11,7 +11,15 @@ properties:
         type: string
       schedule:
         type: string
+      separate_dags:
+        description: Create separate dags per collection
+        type: boolean
+      provider_email:
+        description: Email address to send harvest reports to the provider
+        type: string
+        pattern: "^\\S+@\\S+\\.\\S+$"
     required: [data_path]
+    additionalProperties: false
   sources:
     description: Collections from a provider
     type: object


### PR DESCRIPTION
Closes #301 

- Add additional validation to the catalog schema for provider level email (and that it's a valid email pattern)
- Turns off additional provider properties so unknown properties in a catalog will fail schema validation
- Adds the optional email address to the list of emails when sending the harvest report

DRAFT until this can be tested in place (in AWS) to ensure that a blank email address in the send harvest report task does not cause any additional failures.

TODO: Add test(s) for the send harvest report task if possible.