### PR TITLE
Added wait to the IIIF Driver

### DIFF
--- a/tests/drivers/test_iiif_json.py
+++ b/tests/drivers/test_iiif_json.py
@@ -146,3 +146,8 @@ def test_IiifJsonSource_logging(iiif_test_source, mock_response, caplog):
         "https://collection.edu/iiif/p15795coll29:28/manifest.json missing optional field: 'thumbnail'; searched path: 'thumbnail..@id'"  # noqa: E501
         in caplog.text
     )
+
+
+def test_wait(iiif_test_source):
+    driver = IiifJsonSource("https://example.com/iiif/", wait=2)
+    assert driver, "IiifJsonSource constructor accepts wait parameter"


### PR DESCRIPTION
You can now configure the IIIF driver to wait between HTTP requests similarly to the OAI driver. If you add `wait: n` where n is an integer, to the collection's `args` section.

Closes #299
