### PR TITLE
Fix bug between test arrays and actual csv file row counts

### DIFF
--- a/dlme_airflow/harvester/source_harvester.py
+++ b/dlme_airflow/harvester/source_harvester.py
@@ -15,7 +15,6 @@ def data_source_harvester(task_instance, **kwargs):
     df_and_csv = dataframe_to_file(collection)
     df = df_and_csv["source_df"]
     working_csv = df_and_csv["working_csv"]
-    # subtract 1 from record_count because the first row will be the header
-    dataframe_stats = {"record_count": df.shape[0] - 1}
+    dataframe_stats = {"record_count": df.shape[0]}
     task_instance.xcom_push(key="dataframe_stats", value=dataframe_stats)
     return working_csv

--- a/tests/harvester/test_source_harvester.py
+++ b/tests/harvester/test_source_harvester.py
@@ -25,12 +25,11 @@ def test_dataframe_retrieval_and_profiling(mocker: MockerFixture):
 
     column_headers = ["id", "source"]
     rows = [
-        column_headers,
         ["1", ["Rare Books and Special Collections Library"]],
         ["2", ["Rare Books and Special Collections Library"]],
     ]
 
-    mock_df = pd.DataFrame(rows)
+    mock_df = pd.DataFrame(data=rows, columns=column_headers)
     mock_csv_path = "/metadata/data_path/data.csv"
 
     patched_dataframe_to_file = mocker.patch(


### PR DESCRIPTION
We misunderstood the count difference that included the headers because the test case was including the headers while the normal pandas df does not.

This is a small fix for that.