### PR TITLE
Avoid blank metadata error when getting value

### DIFF
--- a/dlme_airflow/drivers/iiif_json.py
+++ b/dlme_airflow/drivers/iiif_json.py
@@ -94,6 +94,9 @@ class IiifJsonSource(intake.source.base.DataSource):
             )
             # initialize or append to output[name] based on whether we've seen the label
             metadata_value = row.get("value")
+            if not metadata_value:
+                continue
+
             if isinstance(metadata_value[0], dict):
                 metadata_value = metadata_value[0].get("@value")
 


### PR DESCRIPTION
Small bug fix. If the metadata value is an empty string, the check for `dict` fails, and we're likely adding a blank value to the output.

This fixes the error thrown in harvesting if the value is blank.