### PR TITLE
Make record count formula configurable, fixes #312

### DIFF
--- a/catalogs/qnl.yaml
+++ b/catalogs/qnl.yaml
@@ -12,6 +12,7 @@ sources:
       allow_expiration: true
     metadata:
       record_limit: 200
+      record_count_formula: /2
       data_path: qnl/british_library_combined
       post_harvest: "merge_records"
       config: qnl_config

--- a/dlme_airflow/tasks/transform_validation.py
+++ b/dlme_airflow/tasks/transform_validation.py
@@ -7,7 +7,10 @@ from airflow.utils.task_group import TaskGroup
 
 
 def eval_record_count_formula(harvested_record_count, record_count_formula):
-    return eval(f"{harvested_record_count}{record_count_formula}")
+    try:
+        return eval(f"{harvested_record_count}{record_count_formula}")
+    except ZeroDivisionError:
+        return 0
 
 
 def _fetch_transform_output(collection) -> str:

--- a/tests/tasks/test_eval_record_count_formula.py
+++ b/tests/tasks/test_eval_record_count_formula.py
@@ -1,0 +1,7 @@
+from dlme_airflow.tasks.transform_validation import eval_record_count_formula
+
+
+def test_eval_record_count_formula():
+    assert eval_record_count_formula("6", "/2") == 3
+    assert eval_record_count_formula("6", "-2") == 4
+    assert eval_record_count_formula("6", "+2") == 8


### PR DESCRIPTION
This gives us an option to configure a math operation to be performed on the harvested record count. Currently its only needed for QNL, but I can envision other needs. For example, if we harvest all records and then delete some during a legitimate post_harvest task.

Hold for @aaron-collier to review after vacation.