### PR TITLE
Match Sakip Sabanci data-path to dlme-transform expectation

### DIFF
--- a/catalogs/sakip_sabanci_museum.yaml
+++ b/catalogs/sakip_sabanci_museum.yaml
@@ -7,7 +7,7 @@ sources:
     description: "Abidin Dino Archive"
     driver: iiif_json
     metadata:
-      data_path: sakip_sabanci/abidin_dino
+      data_path: sakip_sabanci_museum/abidin_dino
       config: sakip_sabanci_museum
       fields:
         context:
@@ -53,7 +53,7 @@ sources:
     description: "Emirgan Archive"
     driver: iiif_json
     metadata:
-      data_path: sakip_sabanci/emirgan
+      data_path: sakip_sabanci_museum/emirgan
       config: sakip_sabanci_museum
       fields:
         context:
@@ -99,7 +99,7 @@ sources:
     description: "The Arts of Book and Calligraphy Collection"
     driver: iiif_json
     metadata:
-      data_path: sakip_sabanci/kitap_vehat
+      data_path: sakip_sabanci_museum/kitap_vehat
       config: sakip_sabanci_museum
       fields:
         context:
@@ -145,7 +145,7 @@ sources:
     description: "Early Turkish Paintings"
     driver: iiif_json
     metadata:
-      data_path: sakip_sabanci/resim_klksyn
+      data_path: sakip_sabanci_museum/resim_klksyn
       config: sakip_sabanci_museum
       fields:
         context:


### PR DESCRIPTION
This aligns the expected data_path in dlme-transform with the configured path in airflow.

Locally confirm these now pass transform validation:

![Screen Shot 2022-10-19 at 3 46 32 PM](https://user-images.githubusercontent.com/2294288/196818816-d5787bff-4944-4200-916d-4d4d977d09cb.png)
