### PR TITLE
Make sure oai_xml tags include sub field tags

### DIFF
--- a/dlme_airflow/drivers/oai_xml.py
+++ b/dlme_airflow/drivers/oai_xml.py
@@ -141,25 +141,24 @@ class OaiXmlSource(intake.source.base.DataSource):
         """Given an lxml Element will return a dictionary of key/value pairs."""
         result = {}
         for el in rec_metadata.getchildren():
-            tag = self._get_tag(el)
+            sub_element = self._flatten_tree(el)
+            tag = list(sub_element.keys())[0]
+            value = list(sub_element.values())[0].strip()
+
             if tag in result:
                 if isinstance(result[tag], str):
-                    if el.text is not None:
-                        result[tag] = [result[tag], el.text.strip()]
+                    if value is not None:
+                        result[tag] = [result[tag], value]
                     else:
                         result[tag] = [result[tag]]
-                elif el.text is not None:
-                    result[tag].append(el.text.strip())
-            elif el.text is not None:
-                result[tag] = el.text.strip()
-
-            # if the element has child elements add them too
-            if len(el) > 0:
-                result.update(self._flatten_tree(el))
+                elif value is not None:
+                    result[tag].append(value)
+            elif value is not None:
+                result[tag] = value
 
         return result
 
-    # TODO: Ask/Investigate (with jnelson) what the purpose of dtyle=self.dtype
+    
     def _get_schema(self):
         self._open_set()
 

--- a/dlme_airflow/drivers/oai_xml.py
+++ b/dlme_airflow/drivers/oai_xml.py
@@ -158,7 +158,6 @@ class OaiXmlSource(intake.source.base.DataSource):
 
         return result
 
-    
     def _get_schema(self):
         self._open_set()
 

--- a/tests/drivers/test_oai_xml.py
+++ b/tests/drivers/test_oai_xml.py
@@ -24,8 +24,8 @@ def test_mods(requests_mock):
     oai = OaiXmlSource("https://example.org", "mods_no_ocr")
     df = oai.read()
     assert len(df) == 10, "expected number of rows"
-    assert len(df.columns) == 18, "expected number of columns"
-    assert "location_url" in df.columns, "hierarchical data encoded in header"
+    assert len(df.columns) == 14, "expected number of columns"
+    assert "location_shelfLocator" in df.columns, "hierarchical data encoded in header"
 
 
 def test_marc21(requests_mock):
@@ -36,7 +36,7 @@ def test_marc21(requests_mock):
     oai = OaiXmlSource("https://example.org", "marc21")
     df = oai.read()
     assert len(df) == 182, "expected number of rows"
-    assert len(df.columns) == 92, "expected number of columns"
+    assert len(df.columns) == 52, "expected number of columns"
     assert "245_a" in df.columns, "marc field 245 subfield a extracted"
 
 


### PR DESCRIPTION
This rearranges the logic to ensure that we get full tags (i.e. `035_a`) instead of top level (i.e. `035`).

Hold until @jacobthill can test against other OAI collection to ensure this doesn't break non-marc related collections.