### PR TITLE
Avoid blank OAI xml elements

### DIFF
--- a/dlme_airflow/drivers/oai_xml.py
+++ b/dlme_airflow/drivers/oai_xml.py
@@ -142,20 +142,24 @@ class OaiXmlSource(intake.source.base.DataSource):
         result = {}
         for el in rec_metadata.getchildren():
             sub_element = self._flatten_tree(el)
-            if len(sub_element.keys()):
-                tag = list(sub_element.keys())[0]
-                value = list(sub_element.values())[0].strip()
+            if not len(sub_element.keys()):
+                continue
 
-                if tag in result:
-                    if isinstance(result[tag], str):
-                        if value is not None:
-                            result[tag] = [result[tag], value]
-                        else:
-                            result[tag] = [result[tag]]
-                    elif value is not None:
-                        result[tag].append(value)
-                elif value is not None:
-                    result[tag] = value
+            tag = list(sub_element.keys())[0]
+            value = list(sub_element.values())[0].strip()
+
+            if value is None:
+                continue
+
+            if tag not in result:
+                result[tag] = value
+                continue
+
+            if isinstance(result[tag], str):
+                result[tag] = [result[tag], value]
+                continue
+
+            result[tag].append(value)
 
         return result
 

--- a/dlme_airflow/drivers/oai_xml.py
+++ b/dlme_airflow/drivers/oai_xml.py
@@ -142,19 +142,20 @@ class OaiXmlSource(intake.source.base.DataSource):
         result = {}
         for el in rec_metadata.getchildren():
             sub_element = self._flatten_tree(el)
-            tag = list(sub_element.keys())[0]
-            value = list(sub_element.values())[0].strip()
+            if len(sub_element.keys()):
+                tag = list(sub_element.keys())[0]
+                value = list(sub_element.values())[0].strip()
 
-            if tag in result:
-                if isinstance(result[tag], str):
-                    if value is not None:
-                        result[tag] = [result[tag], value]
-                    else:
-                        result[tag] = [result[tag]]
+                if tag in result:
+                    if isinstance(result[tag], str):
+                        if value is not None:
+                            result[tag] = [result[tag], value]
+                        else:
+                            result[tag] = [result[tag]]
+                    elif value is not None:
+                        result[tag].append(value)
                 elif value is not None:
-                    result[tag].append(value)
-            elif value is not None:
-                result[tag] = value
+                    result[tag] = value
 
         return result
 

--- a/dlme_airflow/drivers/oai_xml.py
+++ b/dlme_airflow/drivers/oai_xml.py
@@ -142,14 +142,11 @@ class OaiXmlSource(intake.source.base.DataSource):
         result = {}
         for el in rec_metadata.getchildren():
             sub_element = self._flatten_tree(el)
-            if not len(sub_element.keys()):
+            if not len(sub_element):
                 continue
 
             tag = list(sub_element.keys())[0]
             value = list(sub_element.values())[0].strip()
-
-            if value is None:
-                continue
 
             if tag not in result:
                 result[tag] = value

--- a/tests/data/xml/oai-dc.xml
+++ b/tests/data/xml/oai-dc.xml
@@ -66,6 +66,7 @@
   <dc:source>EISSN: 1614-6840</dc:source>
   <dc:source>Advanced Energy Materials</dc:source>
   <dc:publisher>Wiley-VCH Verlag</dc:publisher>
+  <dc:publisher/>
   <dc:identifier>hal-00999999</dc:identifier>
   <dc:identifier>https://hal.archives-ouvertes.fr/hal-00999999</dc:identifier>
   <dc:source>https://hal.archives-ouvertes.fr/hal-00999999</dc:source>

--- a/tests/drivers/test_oai_xml.py
+++ b/tests/drivers/test_oai_xml.py
@@ -14,6 +14,8 @@ def test_oai_dc(requests_mock):
     assert len(df) == 100, "expected number of rows"
     assert len(df.columns) == 14, "expected number of columns"
     assert "title" in df.columns
+    assert "publisher" in df.columns
+    assert df.iloc[0]["publisher"] == ["HAL CCSD", "Wiley-VCH Verlag"]
 
 
 def test_mods(requests_mock):
@@ -38,6 +40,8 @@ def test_marc21(requests_mock):
     assert len(df) == 182, "expected number of rows"
     assert len(df.columns) == 52, "expected number of columns"
     assert "245_a" in df.columns, "marc field 245 subfield a extracted"
+    assert "035_a" in df.columns, "marc field 035 subfield a extracted"
+    assert len(df.iloc[0]["035_a"]) == 3, "much field 035 subfield a contains 3 values"
 
 
 def test_wait():


### PR DESCRIPTION
@jacobthill the issue with Texas Tech is that in at least one record they provide an empty publisher element. So we get something like:

```
<dc:publisher>Digitized by the Southwest Collection/Special Collections Library.</dc:publisher>
<dc:publisher/>
```

This PR checks if there are any keys once we flatten the value.