### PR TITLE
remove duplicates from qnl when merging

### DIFF
--- a/dlme_airflow/utils/qnl.py
+++ b/dlme_airflow/utils/qnl.py
@@ -1,5 +1,6 @@
 # /bin/python
 import os
+import numpy as np
 import pandas as pd
 
 
@@ -12,6 +13,6 @@ def merge_records(**kwargs):
 
     # merge rows with the same shelf locator
     df_filled = df.fillna("NOT PROVIDED")
-    df_merged = df_filled.groupby("location_shelfLocator").agg(lambda x: x.tolist())
+    df_merged = df_filled.groupby("location_shelfLocator").agg(lambda x: np.unique(x.tolist()))
 
     df_merged.to_csv(working_csv)

--- a/dlme_airflow/utils/qnl.py
+++ b/dlme_airflow/utils/qnl.py
@@ -13,6 +13,8 @@ def merge_records(**kwargs):
 
     # merge rows with the same shelf locator
     df_filled = df.fillna("NOT PROVIDED")
-    df_merged = df_filled.groupby("location_shelfLocator").agg(lambda x: np.unique(x.tolist()))
+    df_merged = df_filled.groupby("location_shelfLocator").agg(
+        lambda x: np.unique(x.tolist())
+    )
 
     df_merged.to_csv(working_csv)


### PR DESCRIPTION
For some fields there are Arabic and English values which we want when merging the English and Arabic records. But some fields like language have English values in both. This drops duplicate values from the list before writing it to the dataframe.