### PR TITLE
[DRAFT | SPIKE] Add oai date filters

### DIFF
--- a/catalogs/qnl.yaml
+++ b/catalogs/qnl.yaml
@@ -11,7 +11,7 @@ sources:
       wait: 2
       allow_expiration: true
       start_date: "2019-10-15T00:00:00Z"
-      end_date: "2020-10-15T19:00:00Z"
+      end_date: "2019-10-15T19:00:00Z"
     metadata:
       record_count_formula: /2
       data_path: qnl/british_library_combined

--- a/catalogs/qnl.yaml
+++ b/catalogs/qnl.yaml
@@ -10,6 +10,8 @@ sources:
       metadata_prefix: mods_no_ocr
       wait: 2
       allow_expiration: true
+      start_date: "2019-10-15T00:00:00Z"
+      end_date: "2020-10-15T19:00:00Z"
     metadata:
       record_count_formula: /2
       data_path: qnl/british_library_combined

--- a/dlme_airflow/drivers/oai_xml.py
+++ b/dlme_airflow/drivers/oai_xml.py
@@ -31,12 +31,16 @@ class OaiXmlSource(intake.source.base.DataSource):
         set=None,
         wait=0,
         allow_expiration=False,
+        start_date=None,
+        end_date=None,
         dtype=None,
         metadata=None,
     ):
         super(OaiXmlSource, self).__init__(metadata=metadata)
         self.collection_url = collection_url
         self.metadata_prefix = metadata_prefix
+        self.start_date = start_date
+        self.end_date = end_date
         self.record_limit = self.metadata.get("record_limit", None)
         self.record_count = 0
         self.set = set
@@ -50,7 +54,12 @@ class OaiXmlSource(intake.source.base.DataSource):
 
     def _open_set(self):
         oai_records = self._collection.ListRecords(
-            set=self.set, metadataPrefix=self.metadata_prefix, ignore_deleted=True
+            **{'set': self.set,
+               'metadataPrefix': self.metadata_prefix,
+               'ignore_deleted': True,
+               'from': self.start_date,
+               'until': self.end_date
+            }
         )
 
         try:


### PR DESCRIPTION
This is currently not working and I think confirms that the sickle library (or our version of it - still investigating) does not honor the `from` and `until` parameters to `ListRecords`.

This QNL query: https://api.qdl.qa/api/oaipmh?verb=ListRecords&metadataPrefix=mods_no_ocr&from=2019-10-15T00:00:00Z&until=2019-10-15T19:00:00Z returns 52 records:

```
<resumptionToken completeListSize="52" cursor="0">10mods_no_ocr</resumptionToken>
```

However, when passing `from` as "2019-10-15T00:00:00Z" and `until` as "2019-10-15T19:00:00Z" to sickle `ListRecords` we get the full data set.

To see this, on this branch run:

```
poetry run bin/get qnl qnl
```

And watch the record number go into the 10,000s.