### PR TITLE
remove redundant princeton collections, revise mapping scripts

### DIFF
--- a/bin/mapping/data_validation.py
+++ b/bin/mapping/data_validation.py
@@ -1,0 +1,58 @@
+from argparse import ArgumentParser
+import json
+
+def main():
+    """Takes the path of the intermediate represenation file as an input and returns a unique,
+     checks for the existence of all required fields. In all records, makes sure urls are all valid,
+     automatically resolves 5 preview urls and 5 resource urls, checks that if a lang code end in -Arab,
+     it has Arabic characters, and checks that if lang code is en or ends in -Latn it has Latin characters
+
+    @example -- python bin/mapping/data_validation.py path_to_file
+
+    """
+    REQUIRED_FIELDS = ["agg_preview", "agg_is_shown_at", "cho_dc_rights", "cho_edm_type", "cho_has_type"]
+    URL_FIELDS = ["agg_preview", "agg_is_shown_at"]
+
+
+    def check_required_fields(record):
+        """Make sure all required fields are present.
+        If not, capture record identifier for report."""
+        bad_records = {}
+        for field in REQUIRED_FIELDS:
+            if not record.get(field):
+                bad_records[field] = []
+                bad_records[field].append(record["id"])
+            elif field in URL_FIELDS:
+                if not record.get(field).get("wr_id"):
+                    bad_records[field] = []
+                    bad_records[field].append(record["id"])
+
+        return bad_records
+
+
+    with open(args.data[0], "r") as file:
+        bad_records = {}
+        for line in file:
+            if line.strip():  # if line is not empty
+                record = json.loads(line)
+
+                for key, value in check_required_fields(record).items():
+                    if bad_records.get(key):
+                        bad_records[key].extend(value)
+                    else:
+                        bad_records[key] = value
+
+        for k,v in bad_records.items():
+            print(k,v)
+
+
+if __name__ == "__main__":
+    # CLI client options.
+    parser = ArgumentParser()
+    parser.add_argument(
+        "data",
+        nargs="+",
+        help="Which data data file do you want to parse?",
+    )
+    args = parser.parse_args()
+    main()

--- a/bin/mapping/data_validation.py
+++ b/bin/mapping/data_validation.py
@@ -11,7 +11,13 @@ def main():
     @example -- python bin/mapping/data_validation.py path_to_file
 
     """
-    REQUIRED_FIELDS = ["agg_preview", "agg_is_shown_at", "cho_dc_rights", "cho_edm_type", "cho_has_type"]
+    REQUIRED_FIELDS = [
+        "agg_preview",
+        "agg_is_shown_at",
+        "cho_dc_rights",
+        "cho_edm_type",
+        "cho_has_type",
+    ]
     URL_FIELDS = ["agg_preview", "agg_is_shown_at"]
 
     def check_required_fields(record):

--- a/bin/mapping/data_validation.py
+++ b/bin/mapping/data_validation.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 import json
 
+
 def main():
     """Takes the path of the intermediate represenation file as an input and returns a unique,
      checks for the existence of all required fields. In all records, makes sure urls are all valid,
@@ -12,7 +13,6 @@ def main():
     """
     REQUIRED_FIELDS = ["agg_preview", "agg_is_shown_at", "cho_dc_rights", "cho_edm_type", "cho_has_type"]
     URL_FIELDS = ["agg_preview", "agg_is_shown_at"]
-
 
     def check_required_fields(record):
         """Make sure all required fields are present.
@@ -29,7 +29,6 @@ def main():
 
         return bad_records
 
-
     with open(args.data[0], "r") as file:
         bad_records = {}
         for line in file:
@@ -42,8 +41,8 @@ def main():
                     else:
                         bad_records[key] = value
 
-        for k,v in bad_records.items():
-            print(k,v)
+        for k, v in bad_records.items():
+            print(k, v)
 
 
 if __name__ == "__main__":

--- a/bin/mapping/get_input_fields.py
+++ b/bin/mapping/get_input_fields.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-d",
-        help="""This flag allows you to pass a path to a traject config file in and a sorted list of fields
+        help="""This flag allows you to pass a path to a traject config file in and returns a sorted list of fields
         in the provider data that are not in the config.""",
     )
     parser.add_argument(

--- a/catalogs/princeton.yaml
+++ b/catalogs/princeton.yaml
@@ -3,23 +3,6 @@ metadata:
   data_path: princeton
   schedule: "20 11 * * *"
 sources:
-  babi_bahai:
-    description: "Islamic Manuscripts"
-    driver: iiif_json
-    args:
-      collection_url: https://figgy.princeton.edu/collections/03556507-2e2b-4393-a50f-5207877c38e8/manifest
-      dtype:
-    metadata:
-      data_path: princeton/babi_bahai
-      config: princeton_mss
-      fields:
-        id:
-          path: "@id"
-        description:
-          path: "description"
-        thumbnail:
-          path: 'thumbnail..@id'
-          optional: true
   islamic_manuscripts:
     description: "Islamic Manuscripts"
     driver: iiif_json
@@ -45,23 +28,6 @@ sources:
       dtype:
     metadata:
       data_path: princeton/movie_posters
-      config: princeton
-      fields:
-        id:
-          path: "@id"
-        description:
-          path: "description"
-        thumbnail:
-          path: 'thumbnail..@id'
-          optional: true
-  ymdi:
-    description: "Yemen Collection"
-    driver: iiif_json
-    args:
-      collection_url: https://figgy.princeton.edu/collections/eff75507-11bf-486b-b422-8fe29638b060/manifest
-      dtype:
-    metadata:
-      data_path: princeton/ymdi
       config: princeton
       fields:
         id:

--- a/catalogs/princeton.yaml
+++ b/catalogs/princeton.yaml
@@ -11,7 +11,7 @@ sources:
       dtype:
     metadata:
       data_path: princeton/islamic_manuscripts
-      config: princeton_mss
+      config: princeton
       fields:
         id:
           path: "@id"


### PR DESCRIPTION
This removes two collections from Princeton that are also included in the Islamic Manuscripts collection. As I worked through mapping Princeton, I revised the mapping debugging scripts to help spot mapping issues. 

The data_validation script is not perfect but it is not used in production. It is used manually to validate traject mappings. It will continue to improve as I map more collections.