### PR TITLE
Add command line option to harvest only a single record by ID for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ and then run `bin/get` with a provider and collection as arguments (optionally y
 $ bin/get yale babylonian --limit 20
 ```
 
+To harvest a single record for a known identifier:
+
+```
+$ bin/get yale babylonian --id some_known_id
+```
+
+
 [BLK]: https://black.readthedocs.io/en/stable/index.html
 [FLK8]: https://flake8.pycqa.org/en/latest/
 [Poetry]: https://python-poetry.org/docs

--- a/bin/get
+++ b/bin/get
@@ -25,13 +25,28 @@ def main(opts):
             collection.catalog.record_limit = opts.limit
         else:
             sys.exit(f"💥 Unable to use --limit with {type(collection.catalog).name} driver")
-    
+
+    # set record id to harvest if it is allowed by the driver (ONLY OAI as of 1/18/23)
+    if opts.id: 
+        if hasattr(collection.catalog, 'identifier'):
+            print(f"Harvesting individual identifier: {opts.id}")
+            collection.catalog.identifier = opts.id
+        else:
+            sys.exit(f"💥 Unable to use --id with {type(collection.catalog).name} driver")
+
     # read the data
     df = collection.catalog.read()
 
+    # select output format, defaults to CSV
+    output_format = opts.format.upper()
+
     # send output to a file or stdout
     out = opts.output if opts.output else sys.stdout
-    df.to_csv(out, index=False)
+    if output_format == "JSON":
+        df.to_json(out)
+    else:
+        df.to_csv(out, index=False)
+        
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Get data from a DLME provider collection as CSV")
@@ -39,7 +54,9 @@ if __name__ == "__main__":
     parser.add_argument('collection', help="The provider's collection (e.g. penn_egyptian")
     parser.add_argument("--output", help="File to write CSV output to")
     parser.add_argument("--limit", type=int, help="Limit output to number of rows")
+    parser.add_argument("--id", help="ID of individual record to harvest")
     parser.add_argument("--log", default="get.log", help="A file path to write log messages")
+    parser.add_argument("--format", default="CSV", help="Output file format")
     opts = parser.parse_args()
 
     logging.basicConfig(filename=opts.log, format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO)

--- a/tests/data/xml/record_12345.xml
+++ b/tests/data/xml/record_12345.xml
@@ -1,0 +1,40 @@
+<OAI-PMH xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.openarchives.org/OAI/2.0/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+<responseDate>2023-01-31T23:27:09Z</responseDate>
+<request verb="GetRecord" identifier="12345" metadataPrefix="mods_no_ocr">https://api.qdl.qa/api/oaipmh</request>
+<GetRecord>
+<record>
+<header>
+<identifier>12345</identifier>
+<datestamp>2020-11-09T18:15:05.676Z</datestamp>
+</header>
+<metadata>
+<mods xmlns="http://www.loc.gov/mods/v3">
+<identifier>12345</identifier>
+<location>
+<shelfLocator>IOR/L/MAR/C/4, f 155-156</shelfLocator>
+<url>http://www.qdl.qa/en/archive/81055/vdc_100101148540.0x000001</url>
+<url access="preview">https://images.qdl.qa/iiif/images/81055/vdc_100022551646.0x000005/IOR_L_MAR_C_4_0322.jp2/full/!1000,1000/0/default.jpg</url>
+<physicalLocation>British Library: India Office Records and Private Papers</physicalLocation>
+</location>
+<recordInfo>
+<recordIdentifer>IOR/L/MAR/C/4, f 155-156</recordIdentifer>
+</recordInfo>
+<titleInfo>
+<title>‘A draught of the South land lately discovered’ ["Tasmania"] and Covering Sheet</title>
+</titleInfo>
+<originInfo>
+<dateIssued>1643/1643</dateIssued>
+<dateCaptured>2019-07-10T12:41:35</dateCaptured>
+</originInfo>
+<language>
+<languageTerm authority="iso639-2b">eng</languageTerm>
+</language>
+<physicalDescription>
+<extent>1 map and 1 folio</extent>
+</physicalDescription>
+<accessCondition type="Use and reproduction" xlink:href="http://www.qdl.qa/en/archive/81055/vdc_100101148540.0x000001#share">Open Government Licence</accessCondition>
+</mods>
+</metadata>
+</record>
+</GetRecord>
+</OAI-PMH>


### PR DESCRIPTION
This adds an option to the command line harvest by ID (using the `GetRecord` OAI method). This could easily be used for a collection configuration if it were a single record as well, but that is unlikely to be useful (and should only require some updated documentation).

Note: This currently only supports OAI collections.