### PR TITLE
Add docker proxy to allow mount access to docker-in-docker tasks

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -73,6 +73,7 @@ x-airflow-common:
     - /opt/app/dlme/dlme-airflow/shared/metadata:/opt/airflow/metadata
     - /opt/app/dlme/dlme-airflow/current/dlme_airflow:/opt/airflow/dlme_airflow
     - /opt/app/dlme/dlme-airflow/current/catalogs:/opt/airflow/catalogs
+    - "/var/run/docker.sock:/var/run/docker.sock"
   user: "503:0"
   depends_on:
     redis:
@@ -132,3 +133,9 @@ services:
       _AIRFLOW_WWW_USER_CREATE: 'true'
       _AIRFLOW_WWW_USER_USERNAME: ${_AIRFLOW_WWW_USER_USERNAME:-airflow}
       _AIRFLOW_WWW_USER_PASSWORD: ${_AIRFLOW_WWW_USER_PASSWORD:-airflow}
+
+  docker-proxy:
+    image: bobrik/socat
+    command: "TCP4-LISTEN:2375,fork,reuseaddr UNIX-CONNECT:/var/run/docker.sock"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,6 +81,7 @@ x-airflow-common:
     - ./metadata:/opt/airflow/metadata
     - ./dlme_airflow:/opt/airflow/dlme_airflow
     - ./catalogs:/opt/airflow/catalogs
+    - "/var/run/docker.sock:/var/run/docker.sock"
   user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-0}"
   depends_on:
     redis:
@@ -168,6 +169,12 @@ services:
       timeout: 10s
       retries: 5
     restart: always
+
+  docker-proxy:
+    image: bobrik/socat
+    command: "TCP4-LISTEN:2375,fork,reuseaddr UNIX-CONNECT:/var/run/docker.sock"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   postgres-db-volume:


### PR DESCRIPTION
This docker proxy is required to allow a DockerOperator based task access to the HOST storage through the docker service as the "docker-in-docker" structure needs this proxy passthrough to make it availble.