### PR TITLE
Remove update-ecs task from circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,29 +97,6 @@ jobs:
             echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
             docker push $IMAGE_NAME:latest
 
-  update_ecs:
-    docker: # NOT the default
-      - image: circleci/python:3.7-stretch-node-browsers
-    steps:
-      - run: sudo pip install awscli
-      - run:
-          name: Update AWS ECS
-          command: |
-            mkdir ~/.aws
-            echo -e "[circle]\naws_access_key_id=$CIRCLE_ACCESS_KEY_ID\naws_secret_access_key=$CIRCLE_SECRET_KEY\n" > ~/.aws/credentials
-            unset AWS_SESSION_TOKEN
-            aws configure set region us-west-2
-            aws configure set output json
-            temp_creds=$(aws sts assume-role --role-session-name DevelopersRole --role-arn $DEV_ROLE_ARN --profile circle | jq .Credentials)
-            export AWS_ACCESS_KEY_ID=$(echo "$temp_creds" | jq .AccessKeyId | xargs)
-            export AWS_SECRET_ACCESS_KEY=$(echo "$temp_creds" | jq .SecretAccessKey | xargs)
-            export AWS_SESSION_TOKEN=$(echo "$temp_creds" | jq .SessionToken | xargs)
-            aws configure list # Show confirmation of config
-            task_arn=$(aws ecs list-task-definitions --family-prefix dlme-airflow --region us-west-2 --sort DESC --max-items 1 | jq --raw-output --exit-status '.taskDefinitionArns[]')
-            cluster_arn=$(aws ecs list-clusters --region us-west-2 | jq --raw-output --exit-status '.clusterArns[] | select(contains(":cluster/dlme-dev"))')
-            # echo -n "task_arn=$task_arn\ncluster_arn=$cluster_arn\n"
-            aws ecs update-service --service dlme-airflow --region us-west-2 --cluster $cluster_arn --task-definition $task_arn --force-new-deployment
-
 workflows:
   version: 2
 
@@ -136,12 +113,6 @@ workflows:
           requires:
             - build
       - publish_to_dockerhub:
-          filters:
-            branches:
-              only: main
-      - update_ecs:
-          requires:
-          - publish_to_dockerhub
           filters:
             branches:
               only: main


### PR DESCRIPTION
As we're no longer deploying to AWS and instead deploying on prem, remove the aws ecs update from the circle build.