### PR TITLE
Mock write to_csv when testing to avoid overwriting fixture data

### DIFF
--- a/tests/utils/test_qnl.py
+++ b/tests/utils/test_qnl.py
@@ -1,4 +1,5 @@
 import pandas
+import pytest
 
 from dlme_airflow.utils.qnl import (
     get_working_csv,
@@ -49,7 +50,16 @@ def test_read_csv_with_lists():
     assert type(df.iloc[0].title) == list
 
 
-def test_merge_records(mocker):
+# This mock prevents writing to the fixture CSV when testing
+@pytest.fixture
+def mock_dataframe_to_csv(monkeypatch):
+    def mock_to_csv(_self, _filename):
+        return True
+
+    monkeypatch.setattr(pandas.DataFrame, "to_csv", mock_to_csv)
+
+
+def test_merge_records(mocker, mock_dataframe_to_csv):
     mocker.patch(
         "dlme_airflow.utils.qnl.get_working_csv",
         return_value="tests/data/csv/qnl.csv",

--- a/tests/utils/test_yale.py
+++ b/tests/utils/test_yale.py
@@ -1,8 +1,20 @@
+import pytest
+import pandas
+
 from dlme_airflow.utils.yale import get_working_csv, remove_babylonian_non_relevant
 from dlme_airflow.models.provider import Provider
 
 
-def test_remove_babylonian_non_relevant(mocker):
+# This mock prevents writing to the fixture CSV when testing
+@pytest.fixture
+def mock_dataframe_to_csv(monkeypatch):
+    def mock_to_csv(_self, _filename):
+        return True
+
+    monkeypatch.setattr(pandas.DataFrame, "to_csv", mock_to_csv)
+
+
+def test_remove_babylonian_non_relevant(mocker, mock_dataframe_to_csv):
     mocker.patch(
         "dlme_airflow.utils.yale.get_working_csv",
         return_value="tests/data/csv/yale.csv",


### PR DESCRIPTION
Fixes #347 
