### PR TITLE
Flatten sub-lists

### DIFF
--- a/dlme_airflow/drivers/iiif_json.py
+++ b/dlme_airflow/drivers/iiif_json.py
@@ -4,7 +4,7 @@ import intake
 import requests
 import jsonpath_ng
 import pandas as pd
-from typing import Any, Optional
+from typing import Any, Optional, Generator
 
 container = "dataframe"
 name = "iiif_json"
@@ -104,7 +104,9 @@ class IiifJsonSource(intake.source.base.DataSource):
                 output[name].append(metadata_value)
             else:
                 output[name] = [metadata_value]
-        return output
+
+        # flatten any nested lists into a single list
+        return {k: list(_flatten_list(v)) for (k, v) in output.items()}
 
     def _get_partition(self, i) -> pd.DataFrame:
 
@@ -159,3 +161,11 @@ def _stringify_and_strip_if_list(possible_list) -> list[str]:
         return [str(elt).strip() for elt in possible_list]
     else:
         return possible_list
+
+
+def _flatten_list(lst: list) -> Generator:
+    for item in lst:
+        if type(item) == list:
+            yield from _flatten_list(item)
+        else:
+            yield item

--- a/tests/drivers/test_iiif_json.py
+++ b/tests/drivers/test_iiif_json.py
@@ -40,6 +40,7 @@ class MockIIIFManifestResponse:
                 {"label": "Title (main)", "value": "A great title of the Middle East"},
                 {"label": "Title (sub)", "value": "Subtitle 1"},
                 {"label": "Title (sub)", "value": "Subtitle 2"},
+                {"label": "Date Created", "value": ["1974"]},
             ],
             "sequences": [
                 {
@@ -125,6 +126,7 @@ def test_IiifJsonSource_df(iiif_test_source, mock_response):
                 "source": ["Rare Books and Special Collections Library"],
                 "title-main": ["A great title of the Middle East"],
                 "title-sub": ["Subtitle 1", "Subtitle 2"],
+                "date-created": ["1974"],
             }
         ]
     )
@@ -151,3 +153,8 @@ def test_IiifJsonSource_logging(iiif_test_source, mock_response, caplog):
 def test_wait(iiif_test_source):
     driver = IiifJsonSource("https://example.com/iiif/", wait=2)
     assert driver, "IiifJsonSource constructor accepts wait parameter"
+
+
+def test_list_encode(iiif_test_source, mock_response):
+    iiif_df = iiif_test_source.read()
+    assert iiif_df["date-created"][0] == ["1974"]


### PR DESCRIPTION
`_flatten_list()` will ensure that lists that are contained in other lists get flattened for IIIF manifest metadata.

So a list like:

```python
["abc", ["def"], ["ghi", "jkl"]]
```

will get flattened into:

```python
["abc", "def", "ghi", "jkl"]
```

Fixes #338
