### PR TITLE
Enable on prem report task

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,16 @@ To harvest a single record for a known identifier:
 $ bin/get yale babylonian --id some_known_id
 ```
 
+### Manually run the report for a collection
+
+This method requires setting the path to the ndjson output directory on execution, this path
+can be wherever the `output-provider-collection.ndjson` file will be found.
+
+Example:
+```
+METADATA_OUTPUT_PATH=$PWD/metadata poetry run bin/report aims aims > report.html
+open report.html # to open in your browser
+```
 
 [BLK]: https://black.readthedocs.io/en/stable/index.html
 [FLK8]: https://flake8.pycqa.org/en/latest/

--- a/bin/report
+++ b/bin/report
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+# A utility for running the configured post harvest tasks for a collection
+
+import sys
+import logging
+import argparse
+
+from signal import signal, SIGPIPE, SIG_DFL  
+from dlme_airflow.models.provider import Provider
+from dlme_airflow.drivers import register_drivers
+from dlme_airflow.utils.qnl import merge_records
+from dlme_airflow.tasks.harvest_report import harvest_report
+
+
+def main(opts):
+    register_drivers()
+    provider = Provider(opts.provider)
+    collection = provider.get_collection(opts.collection)
+    if collection is None:
+        sys.exit(f'Provider "{opts.provider}" does not have a collection "{opts.collection}".')
+
+    params = {
+        'provider': opts.provider,
+        'collection': collection.name,
+        'data_path': collection.data_path(),
+    }
+    print(harvest_report(**params))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Merge data from a DLME provider harvest as CSV")
+    parser.add_argument('provider', help="The DLME provider (e.g. penn)")
+    parser.add_argument('collection', help="The provider's collection (e.g. penn_egyptian")
+    parser.add_argument("--log", default="report.log", help="A file path to write log messages")
+    opts = parser.parse_args()
+
+    logging.basicConfig(filename=opts.log, format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO)
+
+    # Ignore broken pipe errors when running from the command line.
+    # This allows: bin/get penn penn_babylonian | head -10
+    signal(SIGPIPE,SIG_DFL)
+
+    main(opts)

--- a/dlme_airflow/task_groups/etl.py
+++ b/dlme_airflow/task_groups/etl.py
@@ -76,7 +76,7 @@ def build_collection_etl_taskgroup(collection, dag: DAG) -> TaskGroup:
             load_data >> transform
 
         # common tasks
-        transform >> validate_transformation >> index
+        transform >> validate_transformation
 
         # add report unless the environment says not to
         if not os.getenv("SKIP_REPORT"):
@@ -86,9 +86,9 @@ def build_collection_etl_taskgroup(collection, dag: DAG) -> TaskGroup:
             send_report = build_send_harvest_report_task(
                 collection, collection_etl_taskgroup, dag
             )
-            index >> report >> send_report >> etl_complete
+            validate_transformation >> report >> send_report >> index >> etl_complete
         else:
-            index >> etl_complete
+            validate_transformation >> index >> etl_complete
             logging.info("skipping report generation in etl tasks")
 
     return collection_etl_taskgroup

--- a/dlme_airflow/tasks/harvest_report.py
+++ b/dlme_airflow/tasks/harvest_report.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import io
 import json
+import os
 from collections import Counter, defaultdict
 from datetime import date
 import logging
@@ -238,7 +239,7 @@ unresolvable_thumbnails: list[str] = []
 counts: defaultdict = defaultdict(Counter)
 
 
-def main(**kwargs):  # input:, config:):
+def harvest_report(**kwargs):  # input:, config:):
     """Captures all field value counts in counter object and writes report to html file."""
     record_count = 0
     # merge all records into single counter object and write field report
@@ -249,16 +250,15 @@ def main(**kwargs):  # input:, config:):
         "/", "-"
     )  # penn/egyptian-museum => penn-egyptian-museum
 
+    print(f"Starting report for {provider_id} / {collection_id}")
     catalog = catalog_for_provider(f"{provider_id}.{collection_id}")
     config_url = f"https://raw.githubusercontent.com/sul-dlss/dlme-transform/main/traject_configs/{catalog.metadata.get('config')}.rb"
-    config_file = f"/tmp/{provider_id}_{collection_id}_config.rb"
+    config_file = f"tmp/{provider_id}_{collection_id}_config.rb"
     write_file(config_url, config_file)
 
-    input_url = f"https://s3-us-west-2.amazonaws.com/dlme-metadata-dev/output/output-{data_path}.ndjson"
-    input_file = f"/tmp/output-{provider_id}-{collection_id}.ndjson"
+    input_file = f"{os.environ.get('METADATA_OUTPUT_PATH')}/output-{provider_id}-{collection_id}.ndjson"
 
-    write_file(input_url, input_file)
-
+    print(f"Starting file input...")
     with open(input_file, "r") as file:
         for line in file:
             if line.strip():  # if line is not empty
@@ -495,7 +495,7 @@ def build_harvest_report_task(collection, task_group: TaskGroup, dag: DAG):
         task_id=f"{collection.label()}_harvest_report",
         dag=dag,
         task_group=task_group,
-        python_callable=main,
+        python_callable=harvest_report,
         op_kwargs={
             "provider": collection.provider.name,
             "collection": collection.name,

--- a/dlme_airflow/tasks/harvest_report.py
+++ b/dlme_airflow/tasks/harvest_report.py
@@ -250,15 +250,13 @@ def harvest_report(**kwargs):  # input:, config:):
         "/", "-"
     )  # penn/egyptian-museum => penn-egyptian-museum
 
-    print(f"Starting report for {provider_id} / {collection_id}")
     catalog = catalog_for_provider(f"{provider_id}.{collection_id}")
     config_url = f"https://raw.githubusercontent.com/sul-dlss/dlme-transform/main/traject_configs/{catalog.metadata.get('config')}.rb"
-    config_file = f"tmp/{provider_id}_{collection_id}_config.rb"
+    config_file = f"/tmp/{provider_id}_{collection_id}_config.rb"
     write_file(config_url, config_file)
 
-    input_file = f"{os.environ.get('METADATA_OUTPUT_PATH')}/output-{provider_id}-{collection_id}.ndjson"
+    input_file = f"{os.environ.get('METADATA_OUTPUT_PATH')}/output-{data_path}.ndjson"
 
-    print(f"Starting file input...")
     with open(input_file, "r") as file:
         for line in file:
             if line.strip():  # if line is not empty

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -64,7 +64,6 @@ x-airflow-common:
     AIRFLOW_VAR_DATA_MANAGER_EMAIL: 'amcollie@stanford.edu'
     CATALOG_SOURCE: '/opt/airflow/catalogs/catalog.yaml'
     PYTHONPATH: '$PYTHONPATH:/opt/airflow/dlme_airflow'
-    SKIP_REPORT: "true"
     SKIP_HARVEST_VALIDATION: "true"
     DEFAULT_DAG_SCHEDULE: "@weekly"
     METADATA_OUTPUT_PATH: "/opt/app/dlme/datashare"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,7 +64,6 @@ x-airflow-common:
     AIRFLOW_VAR_DATA_MANAGER_EMAIL: 'amcollie@stanford.edu'
     CATALOG_SOURCE: '/opt/airflow/catalogs/catalog.yaml'
     PYTHONPATH: '$PYTHONPATH:/opt/airflow/dlme_airflow'
-    SKIP_REPORT: "${SKIP_REPORT}"
     SKIP_HARVEST_VALIDATION: "true"
     DEFAULT_DAG_SCHEDULE: "@weekly"
     METADATA_OUTPUT_PATH: "${PWD}/metadata"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+import os
 from dlme_airflow.drivers import register_drivers
 
 register_drivers()
+
+# Set environment variable for tests
+os.environ["METADATA_OUTPUT_PATH"] = "tests/data/ndjson"

--- a/tests/tasks/test_harvest_report.py
+++ b/tests/tasks/test_harvest_report.py
@@ -51,7 +51,7 @@ def test_successful_harvest_report(
         "collection": "test",
         "data_path": "testmuseum",
     }
-    doc = harvest_report.main(**options)
+    doc = harvest_report.harvest_report(**options)
 
     assert "h2" in doc
     # Coverage Report


### PR DESCRIPTION
This is a small PR that does a couple of things.

- There is a small change to read the `ndjson` (IR: intermediate representation) from the local shared storage instead of fetching it from S3
- This adds a method for calling the report manually from the command line for testing/development.

Note: The codeclimate failure below is an existing complexity warning, this simply changed the name of the method. Refactoring would be for a different ticket, but it's unlikely to improve the complexity of this task at this time.