### PR TITLE
Ensure unique id is not a list

### DIFF
--- a/dlme_airflow/utils/dataframe.py
+++ b/dlme_airflow/utils/dataframe.py
@@ -33,9 +33,17 @@ def dataframe_to_file(collection):
         .get("id")
         .get("name_in_dataframe", "id")
     )
-    source_df = collection.catalog.read().drop_duplicates(
-        subset=[unique_id], keep="first"
-    )
+
+    source_df = collection.catalog.read()
+
+    # Ensure that the unique id is not a list or else the call to
+    # drop_duplicates below will fail. If a list is the unique_id value will be
+    # replaced with the first element of the list that is contained.
+    if len(source_df[unique_id]) > 0 and type(source_df[unique_id][0]) == list:
+        source_df[unique_id] = source_df[unique_id].apply(lambda l: l[0])
+
+    source_df = source_df.drop_duplicates(subset=[unique_id], keep="first")
+
     source_df.to_csv(working_csv, index=False)
 
     return {"working_csv": working_csv, "source_df": source_df}


### PR DESCRIPTION
Ensure that the unique id is NOT a list or else it will fail deduplication. Without this all OAI harvests will fail with an error like:

```
TypeError: unhashable type: 'list'
```

Alternatively it might be possible to fix the problem upstream in the
OAI harvesting code that seemed to get broken in 9ef80eea9f87d5dd61f923f73c842936774b4453
