### PR TITLE
Incremental harvest

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ driver class that extends `intake.source.base.DataSource`. In catalogs sources
 that use this driver, set the driver value to *iiif_json*.
 
 Under the *args* section, the *collection_url* should be an URL to the JSON file
-that contains links to other manfest files under it's *manifests* field. The
+that contains links to other manifest files under it's *manifests* field. The
 catalog *args* should also contain the *dtype* values for the data source.
 
 In the *metadata* section, the *current_directory* value is the same as the
@@ -209,6 +209,42 @@ exploring_egypt:
         optional: true
 
 ```
+
+### OAI-PMH Catalog
+
+The `OaiXmlSource` Intake driver allows for harvesting of metadata from [OAI-PMH](https://www.openarchives.org/pmh/) services. The OAI-PMH protocol allows for multiple types of XML based metadata to be made available. DLME currently understands Dublin Core, MODS, and MARCXML. By default the driver will only harvest records that have been updated or created since the last successful harvest. Incremental harvesting can be turned off with the *full_harvest* option (see below).
+
+There are several settings in the *args* section that need to be configured for the driver to work properly.
+
+- **collection_url**: the URL for a OAI-PMH endpoint
+- **metadata_prefix**: what type of metadata should be harvested: `oai_dc`, `mods`, or `marc21`
+- **set**: indicate which OAI-PMH set to harvest from (optional)
+- **wait**: number of seconds to wait between requests to the server (optional)
+- **fields**: a mapping of property names and XPath locations where to find the value in the XML
+- **full_harvest**: when set to a value this will turn off incremental harvesting and fetch all records on each run
+
+#### Example source entry:
+
+```yaml
+voice_of_america:
+  description: "Voice of America radio recordings"
+  driver: oai_xml
+  args:
+    collection_url: https://cdm15795.contentdm.oclc.org/oai/oai.php
+    metadata_prefix: oai_dc
+    set: p15795coll40
+    wait: 2
+  metadata:
+    data_path: auc/voice_of_america
+    config: auc
+    fields:
+      id:
+        path: "//header:identifier"
+        namespace:
+          header: "http://www.openarchives.org/OAI/2.0/"
+        optional: true
+```
+
 
 ### Getting Data
 

--- a/dlme_airflow/drivers/iiif_json.py
+++ b/dlme_airflow/drivers/iiif_json.py
@@ -109,7 +109,6 @@ class IiifJsonSource(intake.source.base.DataSource):
         return {k: list(_flatten_list(v)) for (k, v) in output.items()}
 
     def _get_partition(self, i) -> pd.DataFrame:
-
         # if we are over the defined limit return an empty DataFrame right away
         if self.record_limit is not None and self.record_count > self.record_limit:
             return pd.DataFrame()

--- a/dlme_airflow/drivers/xml.py
+++ b/dlme_airflow/drivers/xml.py
@@ -36,7 +36,6 @@ class XmlSource(intake.source.base.DataSource):
     def _construct_fields(self, record_el: etree) -> dict:
         record: Dict[str, (str | List)] = {}
         for field in self._path_expressions:
-
             # look for the field in our data
             path = self._path_expressions[field]["path"]
             namespace = self._path_expressions[field].get("namespace", {})

--- a/dlme_airflow/models/collection.py
+++ b/dlme_airflow/models/collection.py
@@ -6,6 +6,7 @@ class Collection(object):
         self.name = collection
         self.provider = provider
         self.catalog = catalog_for_provider(f"{self.provider.name}.{self.name}")
+        self.last_harvest_start_date = None
 
     def label(self):
         return f"{self.provider.name}_{self.name}"

--- a/dlme_airflow/tasks/harvest_report.py
+++ b/dlme_airflow/tasks/harvest_report.py
@@ -351,7 +351,6 @@ def harvest_report(**kwargs):  # input:, config:):
                     attr(cls="report")
                     h2("Resource Report")
                     with ul() as u_list:
-
                         u_list.add(
                             li(
                                 f"{counts['agg_preview']['wr_id']} of {record_count} records had valid urls to thumbnail images."

--- a/dlme_airflow/utils/dataframe.py
+++ b/dlme_airflow/utils/dataframe.py
@@ -22,7 +22,7 @@ def dataframe_from_file(collection) -> pd.DataFrame:
 
 # TODO: An Error is thrown on line 22 if working_directory is not found in
 #       the metadata. Need to handle this error.
-def dataframe_to_file(collection):
+def dataframe_to_file(collection, last_harvest_start_date=None):
     working_csv = datafile_for_collection(collection)
     os.makedirs(os.path.dirname(working_csv), exist_ok=True)
 
@@ -31,6 +31,11 @@ def dataframe_to_file(collection):
         .get("id")
         .get("name_in_dataframe", "id")
     )
+
+    # We need to set last_harvest_start_date here since the catalog metadata comes
+    # from the YAML Intake catalog file, but in some cases (oai driver currently)
+    # we need the Intake driver to know about the last time the harvest ran successfully.
+    setattr(collection.catalog, "last_harvest_start_date", last_harvest_start_date)
 
     source_df = collection.catalog.read()
 

--- a/dlme_airflow/utils/schema.py
+++ b/dlme_airflow/utils/schema.py
@@ -12,7 +12,6 @@ def get_schema(url) -> Optional[dict]:
 
     # if we've got html
     if "html" in resp.headers.get("content-type", ""):
-
         # parse the html
         doc = BeautifulSoup(resp.content, "html.parser")
 


### PR DESCRIPTION
Adds incremental harvesting of OAI-PMH endpoints. The `data_source_harvester()` task function has been updated to fetch the last *successful* [DagRun] and pass the datetime that the Dag started to `dataframe_to_file`, which ensures that the `Collection` has `last_harvest_start_date` set on it. This is currently only used by the `OaiXmlSource` driver, which will set the `from` OAI-PMH parameter using the date portion.

By default all OAI-PMH harvests are incremental. But if you want to turn on full harvesting for every run you can set `full_harvest` in the catalog YAML (see the README.md for details).

Closes #340

[DagRun]: https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/dagrun/index.html#airflow.models.dagrun.DagRun
