### PR TITLE
Archive task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,4 +135,4 @@ dmypy.json
 /metadata/**/*
 metadata
 /ssh
-
+test-working

--- a/dlme_airflow/tasks/archive.py
+++ b/dlme_airflow/tasks/archive.py
@@ -1,0 +1,119 @@
+import shutil
+import hashlib
+import logging
+
+from typing import Union
+from pathlib import Path
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.utils.task_group import TaskGroup
+
+from dlme_airflow.utils.dataframe import datafile_for_collection
+
+
+def archive_collection(collection) -> Union[str, None]:
+    """Pass in a Collection and get back the path for an archive that was created"""
+    src = Path(datafile_for_collection(collection))
+
+    # don't clutter up the archive with empty data files, which can happen with
+    # incremental harvests of oai-pmh endpoints
+    if not has_data(src):
+        logging.info("skipping archive for %s since it has no data")
+        return None
+
+    dest = archive_path(src)
+    if not has_new_data(src, dest):
+        logging.info("skipping archive for %s since it has no new data")
+        return None
+
+    if not dest.parent.is_dir():
+        dest.parent.mkdir(parents=True)
+
+    logging.info("archiving %s to %s", src, dest)
+    shutil.copy(src, dest)
+
+    return str(dest)
+
+
+def archive_task(collection, task_group: TaskGroup, dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id=f"archive_{collection.label()}",
+        task_group=task_group,
+        dag=dag,
+        python_callable=archive_collection,
+        op_kwargs={
+            "collection": collection,
+        },
+    )
+
+
+def now() -> datetime:
+    # this is here so it can be mocked easily in the test
+    return datetime.now()
+
+
+def archive_path(datafile_path: Path) -> Path:
+    """Pass in a Path for the data file and get back the archive path."""
+    return (
+        datafile_path.parent
+        / "archive"
+        / ("data-" + now().strftime("%Y%m%d%H%M%S") + datafile_path.suffix)
+    )
+
+
+def has_data(datafile_path: Path) -> bool:
+    """Returns true if the data file has data, and not just a column headers."""
+    line_count = short_count(datafile_path)
+    if datafile_path.suffix == ".csv" and line_count == 2:
+        return True
+    elif datafile_path.suffix == ".json" and line_count > 0:
+        return True
+    else:
+        return False
+
+
+def short_count(path: Path) -> int:
+    """Returns the number of lines in the file, but if it's more than 2 just return 2"""
+    count = 0
+    for _ in path.open():
+        count += 1
+        if count == 2:
+            break
+    return count
+
+
+def has_new_data(src: Path, dest: Path) -> bool:
+    prev = previous_archive(dest)
+    if prev is None:
+        return True
+
+    src_digest = digest(src)
+    prev_digest = digest(prev)
+
+    return src_digest != prev_digest
+
+
+def digest(path: Path) -> str:
+    sha256 = hashlib.sha256()
+    fh = path.open("rb")
+    while True:
+        buff = fh.read(1024)
+        if not buff:
+            break
+        sha256.update(buff)
+    return sha256.hexdigest()
+
+
+def previous_archive(path: Path) -> Union[Path, None]:
+    # if there is no archive dir then there is no previous archive file
+    if not path.parent.is_dir():
+        return None
+
+    # sort the filenames in order of their datetime
+    archive_files = sorted(path.parent.iterdir())
+    if len(archive_files) > 0:
+        return archive_files[-1]
+    else:
+        return None

--- a/dlme_airflow/utils/dataframe.py
+++ b/dlme_airflow/utils/dataframe.py
@@ -10,14 +10,15 @@ def datafile_for_collection(collection):
     return working_csv
 
 
-# TODO: If not files are found / dir is empty / etc, this raising an error.
-#       We should handle this error more cleanly.
 def dataframe_from_file(collection) -> pd.DataFrame:
-    """Returns existing DLME metadata as a Pandas dataframe from S3
+    """Returns existing DLME metadata for a collection as a Pandas dataframe
 
     @param -- collection
     """
-    return pd.read_csv(datafile_for_collection(collection))
+    csv_path = datafile_for_collection(collection)
+    if not os.path.isfile(csv_path):
+        raise Exception(f"Unable to find CSV at f{csv_path}")
+    return pd.read_csv(csv_path)
 
 
 # TODO: An Error is thrown on line 22 if working_directory is not found in

--- a/tests/tasks/test_archive.py
+++ b/tests/tasks/test_archive.py
@@ -1,0 +1,136 @@
+import pytest
+import shutil
+import datetime
+
+from pathlib import Path
+from dlme_airflow.models.collection import Collection
+from dlme_airflow.models.provider import Provider
+from dlme_airflow.tasks.archive import archive_collection
+
+test_working = Path("test-working")
+test_dir = test_working / "aub" / "aco"
+test_csv = test_dir / "data.csv"
+test_json = test_dir / "data.json"
+test_now = datetime.datetime(2023, 3, 13, 18, 6, 31)
+
+
+@pytest.fixture
+def mock_csv(monkeypatch):
+    def mock(_):
+        return str(test_csv.absolute())
+
+    monkeypatch.setattr("dlme_airflow.tasks.archive.datafile_for_collection", mock)
+
+
+@pytest.fixture
+def mock_json(monkeypatch):
+    def mock(_):
+        return str(test_json.absolute())
+
+    monkeypatch.setattr("dlme_airflow.tasks.archive.datafile_for_collection", mock)
+
+
+@pytest.fixture
+def mock_now(monkeypatch):
+    monkeypatch.setattr("dlme_airflow.tasks.archive.now", lambda: test_now)
+
+
+@pytest.fixture
+def setup_dir():
+    if test_csv.parent.is_dir():
+        shutil.rmtree(test_dir)
+    test_csv.parent.mkdir(parents=True)
+
+
+def test_csv_with_data(setup_dir, mock_csv, mock_now):
+    provider = Provider("aub")
+    collection = Collection(provider, "aco")
+
+    fh = test_csv.open("w")
+    fh.write("id,author,title\n")
+    fh.write("1,Jalāl al-Dīn Muḥammad Rūmī,Maṭnawīye Ma'nawī\n")
+    fh.close()
+
+    result = archive_collection(collection=collection)
+
+    assert result is not None
+    assert result.endswith(
+        "test-working/aub/aco/archive/data-20230313180631.csv"
+    ), "returned archived filename"
+    assert Path(result).is_file(), "archived file exists"
+    assert test_csv.is_file(), "original data file should still be there"
+
+
+def test_empty_csv(setup_dir, mock_csv, mock_now):
+    provider = Provider("aub")
+    collection = Collection(provider, "aco")
+    test_csv.touch()
+
+    result = archive_collection(collection=collection)
+
+    assert result is None, "no archived file for empty csv"
+
+
+def test_csv_with_header(setup_dir, mock_csv, mock_now):
+    provider = Provider("aub")
+    collection = Collection(provider, "aco")
+
+    test_csv.open("w").write("id,author,title\n")
+
+    result = archive_collection(collection=collection)
+
+    assert result is None, "no archived file for csv with no data"
+
+
+# mock_now not used here since we want to call at two different times
+def test_identical_csv(setup_dir, mock_csv):
+    provider = Provider("aub")
+    collection = Collection(provider, "aco")
+
+    fh = test_csv.open("w")
+    fh.write("id,author,title\n")
+    fh.write("1,Jalāl al-Dīn Muḥammad Rūmī,Maṭnawīye Ma'nawī\n")
+    fh.close()
+
+    result = archive_collection(collection=collection)
+    assert result is not None and result.endswith(".csv"), "first archive is created"
+
+    result = archive_collection(collection=collection)
+    assert result is None, "identical archive not created"
+
+    fh = test_csv.open("w")
+    fh.write("id,author,title\n")
+    fh.write("1,Jalāl al-Dīn Muḥammad Rūmī,Maṭnawīye Ma'nawī\n")
+    fh.write("2,Tawfiq al-Hakim,Usfur min Sharq\n")
+    fh.close()
+
+    result = archive_collection(collection=collection)
+    assert result is not None and result.endswith(".csv"), "new data creates an archive"
+
+
+def test_json_with_data(setup_dir, mock_json, mock_now):
+    provider = Provider("aub")
+    collection = Collection(provider, "aco")
+
+    fh = test_json.open("w")
+    fh.write("""{"id": 1, "title": "Maṭnawīye Ma'nawī"}\n""")
+    fh.close()
+
+    result = archive_collection(collection=collection)
+
+    assert result is not None
+    assert result.endswith(
+        "test-working/aub/aco/archive/data-20230313180631.json"
+    ), "returned archived json filename"
+    assert Path(result).is_file(), "archived file exists"
+    assert test_json.is_file(), "original data file should still be there"
+
+
+def test_empty_json(setup_dir, mock_json, mock_now):
+    provider = Provider("aub")
+    collection = Collection(provider, "aco")
+    test_json.touch()
+
+    result = archive_collection(collection=collection)
+
+    assert result is None, "no archived file for empty json"


### PR DESCRIPTION
Add an archive task to the end of the ETL pipeline. The task will archive the harvested data to an archive folder within the working directory using a timestamped filename.

If the harvested data is empty (just a CSV header) then the archive is not written. If the harvested data is identical (sha256 hash) of the previous archive it also is not written. This is done to prevent the archive directory from filling up with unnecessary files.

Closes #364
