### PR TITLE
Transform validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,4 +135,3 @@ dmypy.json
 /metadata/**/*
 metadata
 /ssh
-test-working

--- a/dlme_airflow/models/collection.py
+++ b/dlme_airflow/models/collection.py
@@ -14,6 +14,6 @@ class Collection(object):
     def data_path(self):
         return self.catalog.metadata.get("data_path")
 
-    def intermidiate_representation_location(self):
+    def intermediate_representation_location(self):
         normalized_data_path = self.data_path().replace("/", "-").replace("_", "-")
         return f"output-{normalized_data_path}.ndjson"

--- a/dlme_airflow/tasks/index.py
+++ b/dlme_airflow/tasks/index.py
@@ -19,7 +19,7 @@ def index_collection(**kwargs):
         "Content-type": "application/json",
     }
     payload = {
-        "url": collection.intermidiate_representation_location(),
+        "url": collection.intermediate_representation_location(),
     }
     response = requests.post(api_endpoint, data=json.dumps(payload), headers=headers)
     return response.json()["message"]

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -9,7 +9,7 @@ def test_Collection():
     collection = Collection(provider, "aco")
     assert collection.label() == "aub_aco"
     assert collection.data_path() == "aub/aco"
-    assert collection.intermidiate_representation_location() == "output-aub-aco.ndjson"
+    assert collection.intermediate_representation_location() == "output-aub-aco.ndjson"
 
 
 def test_Provider_NotFound():

--- a/tests/tasks/test_archive.py
+++ b/tests/tasks/test_archive.py
@@ -40,6 +40,10 @@ def setup_dir():
     if test_csv.parent.is_dir():
         shutil.rmtree(test_dir)
     test_csv.parent.mkdir(parents=True)
+    yield
+    # teardown
+    if test_working.is_dir():
+        shutil.rmtree(test_working)
 
 
 def test_csv_with_data(setup_dir, mock_csv, mock_now):


### PR DESCRIPTION
Removes AWS specific code related to transform validation, and compares the length of the DataFrame for the harvested data with the transformed NDJSON data stored in the "metadata" directory.

This is in draft awaiting further information about what type of validation notification is needed. Or alternatively that could be a separate PR. Validation failures will halt workflows, so they should be pretty obvious. The validation task log will have information about why it failed.

Closes #366
