### PR TITLE
Remove restart: always from docker-compose dev

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -99,7 +99,6 @@ services:
       test: ["CMD", "pg_isready", "-U", "airflow"]
       interval: 5s
       retries: 5
-    restart: always
 
   redis:
     image: redis:latest
@@ -109,7 +108,6 @@ services:
       interval: 5s
       timeout: 30s
       retries: 50
-    restart: always
 
   airflow-webserver:
     <<: *airflow-common
@@ -121,7 +119,6 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
-    restart: always
 
   airflow-scheduler:
     <<: *airflow-common
@@ -131,7 +128,6 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
-    restart: always
 
   airflow-worker:
     <<: *airflow-common
@@ -143,7 +139,6 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
-    restart: always
 
   airflow-init:
     <<: *airflow-common
@@ -165,7 +160,6 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
-    restart: always
 
   docker-proxy:
     image: bobrik/socat


### PR DESCRIPTION
This should keep the docker images from automatically starting and not stopping