### PR TITLE
Use the environment variable for the metadata path in validation

### DIFF
--- a/dlme_airflow/tasks/transform_validation.py
+++ b/dlme_airflow/tasks/transform_validation.py
@@ -64,5 +64,7 @@ def get_transformed_record_count(collection: Collection) -> int:
 
 def get_transformed_path(collection) -> str:
     transform_file = collection.intermediate_representation_location()
-    transform_dir = os.path.join("metadata", transform_file)
-    return os.path.abspath(transform_dir)
+    transform_dir = os.path.join(
+        os.environ.get("METADATA_OUTPUT_PATH", ""), transform_file
+    )
+    return transform_dir

--- a/tests/tasks/test_transform_validation.py
+++ b/tests/tasks/test_transform_validation.py
@@ -55,7 +55,7 @@ def setup_ndjson(monkeypatch):
 def test_transform_path():
     collection = Collection(Provider("princeton"), "islamic_manuscripts")
     path = transform_validation.get_transformed_path(collection)
-    assert str(path).endswith("metadata/output-princeton-islamic-manuscripts.ndjson")
+    assert str(path).endswith("ndjson/output-princeton-islamic-manuscripts.ndjson")
 
 
 def test_validation_passes(caplog, cleanup, setup_df, setup_ndjson):


### PR DESCRIPTION
The metadata path is now based on an env var set in docker-compose and prod docker-compose for use with on prem deployment.