### PR TITLE
Mount the metadata output and archive share for access by airflow

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -75,8 +75,10 @@ x-airflow-common:
   volumes:
     - /opt/app/dlme/dlme-airflow/shared/logs:/opt/airflow/logs
     - /opt/app/dlme/dlme-airflow/shared/source_data:/opt/airflow/working
+    - /opt/app/dlme/dlme-airflow/shared/archive:/opt/airflow/archive
     - /opt/app/dlme/dlme-airflow/current/dlme_airflow:/opt/airflow/dlme_airflow
     - /opt/app/dlme/dlme-airflow/current/catalogs:/opt/airflow/catalogs
+    - /opt/app/dlme/datashare/:/opt/airflow/metadata
     - "/var/run/docker.sock:/var/run/docker.sock"
   user: "503:0"
   depends_on:


### PR DESCRIPTION
Currently, this path is only available to transform as it is directly mounted through the docker host. We need this mount available within airflow for the validation task.