### PR TITLE
Fix ndjson path in transform validation

### DIFF
--- a/dlme_airflow/tasks/transform_validation.py
+++ b/dlme_airflow/tasks/transform_validation.py
@@ -63,6 +63,7 @@ def get_transformed_record_count(collection: Collection) -> int:
 
 
 def get_transformed_path(collection) -> str:
+    # TODO: maybe this should be a method on the Collection class?
     transform_file = collection.intermediate_representation_location()
-    transform_dir = os.path.join("metadata", transform_file)
+    transform_dir = os.path.join("metadata", collection.data_path(), transform_file)
     return os.path.abspath(transform_dir)

--- a/tests/tasks/test_transform_validation.py
+++ b/tests/tasks/test_transform_validation.py
@@ -55,7 +55,9 @@ def setup_ndjson(monkeypatch):
 def test_transform_path():
     collection = Collection(Provider("princeton"), "islamic_manuscripts")
     path = transform_validation.get_transformed_path(collection)
-    assert str(path).endswith("metadata/output-princeton-islamic-manuscripts.ndjson")
+    assert str(path).endswith(
+        "metadata/princeton/islamic_manuscripts/output-princeton-islamic-manuscripts.ndjson"
+    )
 
 
 def test_validation_passes(caplog, cleanup, setup_df, setup_ndjson):


### PR DESCRIPTION
The transform validation was expecting the ndjson path to be in a location that left off the data_path component of the path. Adding it should hopefully allow transform validation to work in deployed Airflow environments.
