### PR TITLE
Remove debug character encoding for qnl

### DIFF
--- a/dlme_airflow/drivers/oai_xml.py
+++ b/dlme_airflow/drivers/oai_xml.py
@@ -124,8 +124,8 @@ class OaiXmlSource(intake.source.base.DataSource):
                     output[field] = []
 
                 for data in result:
-                    value = data.text.strip().strip("'").strip('"').replace('"', "###")
-                    output[field].append(value)
+                    output[field].append(data.text.strip())
+
         return output
 
     def _get_tag(self, el):

--- a/tests/drivers/test_oai_xml.py
+++ b/tests/drivers/test_oai_xml.py
@@ -29,7 +29,7 @@ def test_oai_record(requests_mock):
     assert len(df) == 1, "One record expected"
     assert df.iloc[0]["identifier"] == ["12345"]
     assert df.iloc[0]["title"] == [
-        "‘A draught of the South land lately discovered’ [###Tasmania###] and Covering Sheet"
+        '‘A draught of the South land lately discovered’ ["Tasmania"] and Covering Sheet'
     ]
 
 


### PR DESCRIPTION
Closes #406 

These character encodings where used when debugging QNL data being translated to CSV, since we are now using JSON this debugging in no longer necessary.