### PR TITLE
rename harvest_report to maaping_report

### DIFF
--- a/bin/report
+++ b/bin/report
@@ -6,11 +6,11 @@ import sys
 import logging
 import argparse
 
-from signal import signal, SIGPIPE, SIG_DFL  
+from signal import signal, SIGPIPE, SIG_DFL
 from dlme_airflow.models.provider import Provider
 from dlme_airflow.drivers import register_drivers
 from dlme_airflow.utils.qnl import merge_records
-from dlme_airflow.tasks.harvest_report import harvest_report
+from dlme_airflow.tasks.mapping_report import mapping_report
 
 
 def main(opts):
@@ -25,7 +25,7 @@ def main(opts):
         'collection': collection.name,
         'data_path': collection.data_path(),
     }
-    print(harvest_report(**params))
+    print(mapping_report(**params))
 
 
 if __name__ == "__main__":

--- a/dlme_airflow/task_groups/etl.py
+++ b/dlme_airflow/task_groups/etl.py
@@ -13,9 +13,9 @@ from dlme_airflow.tasks.post_harvest import build_post_harvest_task
 from dlme_airflow.tasks.transform import build_transform_task
 from dlme_airflow.tasks.index import index_task
 from dlme_airflow.tasks.archive import archive_task
-from dlme_airflow.tasks.harvest_report import build_harvest_report_task
+from dlme_airflow.tasks.mapping_report import build_mapping_report_task
 from dlme_airflow.tasks.harvest_validator import build_validate_harvest_task
-from dlme_airflow.tasks.send_harvest_report import build_send_harvest_report_task
+from dlme_airflow.tasks.send_mapping_report import build_send_mapping_report_task
 from dlme_airflow.tasks.transform_validation import build_transform_validation_task
 
 
@@ -81,10 +81,10 @@ def build_collection_etl_taskgroup(collection, dag: DAG) -> TaskGroup:
 
         # add report unless the environment says not to
         if not os.getenv("SKIP_REPORT"):
-            report = build_harvest_report_task(
+            report = build_mapping_report_task(
                 collection, collection_etl_taskgroup, dag
             )
-            send_report = build_send_harvest_report_task(
+            send_report = build_send_mapping_report_task(
                 collection, collection_etl_taskgroup, dag
             )
             validate_transformation >> report >> send_report >> index

--- a/dlme_airflow/tasks/mapping_report.py
+++ b/dlme_airflow/tasks/mapping_report.py
@@ -239,7 +239,7 @@ unresolvable_thumbnails: list[str] = []
 counts: defaultdict = defaultdict(Counter)
 
 
-def harvest_report(**kwargs):  # input:, config:):
+def mapping_report(**kwargs):  # input:, config:):
     """Captures all field value counts in counter object and writes report to html file."""
     record_count = 0
     # merge all records into single counter object and write field report
@@ -487,12 +487,12 @@ def harvest_report(**kwargs):  # input:, config:):
     return doc.render()
 
 
-def build_harvest_report_task(collection, task_group: TaskGroup, dag: DAG):
+def build_mapping_report_task(collection, task_group: TaskGroup, dag: DAG):
     return PythonOperator(
-        task_id=f"{collection.label()}_harvest_report",
+        task_id=f"{collection.label()}_mapping_report",
         dag=dag,
         task_group=task_group,
-        python_callable=harvest_report,
+        python_callable=mapping_report,
         op_kwargs={
             "provider": collection.provider.name,
             "collection": collection.name,

--- a/dlme_airflow/tasks/send_mapping_report.py
+++ b/dlme_airflow/tasks/send_mapping_report.py
@@ -17,7 +17,7 @@ def email_callback(task_instance, task, **kwargs):
     )
 
 
-def build_send_harvest_report_task(collection, task_group: TaskGroup, dag: DAG):
+def build_send_mapping_report_task(collection, task_group: TaskGroup, dag: DAG):
     return PythonOperator(
         task_id=f"{collection.label()}_harvest_send_report",
         dag=dag,
@@ -28,24 +28,24 @@ def build_send_harvest_report_task(collection, task_group: TaskGroup, dag: DAG):
     )
 
 
-def send_harvest_report_tasks(provider, task_group: TaskGroup, dag: DAG):
+def send_mapping_report_tasks(provider, task_group: TaskGroup, dag: DAG):
     task_array = []
     source = catalog_for_provider(provider)
 
     try:
         collections = list(source).__iter__()
         for collection in collections:
-            send_report_task = build_send_harvest_report_task(
+            send_report_task = build_send_mapping_report_task(
                 collection, task_group, dag
             )
             task_array.append(send_report_task)
     except TypeError:
-        return build_send_harvest_report_task("", task_group, dag)
+        return build_send_mapping_report_task("", task_group, dag)
 
     return task_array
 
 
-def build_send_harvest_report_taskgroup(provider, dag: DAG) -> TaskGroup:
-    send_harvest_report_taskgroup = TaskGroup(group_id="send_harvest_report")
+def build_send_mapping_report_taskgroup(provider, dag: DAG) -> TaskGroup:
+    send_mapping_report_taskgroup = TaskGroup(group_id="send_mapping_report")
 
-    return send_harvest_report_tasks(provider, send_harvest_report_taskgroup, dag)
+    return send_mapping_report_tasks(provider, send_mapping_report_taskgroup, dag)


### PR DESCRIPTION
The name harvest_report was misleading; its a report on the traject mapping results. 