### PR TITLE
Add new traject config validation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,3 +292,16 @@ open report.html # to open in your browser
 [ETL]: https://en.wikipedia.org/wiki/Extract,_transform,_load
 [MYPY]: https://mypy.readthedocs.io/
 [YAMLLINT]: https://yamllint.readthedocs.io/en/stable/index.html
+
+### Validate a traject config file
+
+There is a utility for validating traject mappings when the input file is json. It will compare 
+all fields in the input data against all fields in the traject config and write a report listing 
+unmapped fields and fields the traject config attempts to map that do not exist in the input data.
+Call it with the data path used to invoke the traject transformation.
+
+Example:
+```
+bin/validate-traject qnl
+```
+

--- a/bin/validate-traject
+++ b/bin/validate-traject
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+# A utility for validating the traject mapping to ensure that it catches all fields
+# present in the input data and doesn't attempt to map fields that are not present.
+
+import argparse
+import glob
+import json
+import logging
+import os
+import sys
+
+def get_paths_and_trajects(provider):
+    with open(f"{os.getcwd()}/../dlme-transform/config/metadata_mapping.json") as f:
+        metatdata_mapping = json.load(f)
+    for i in metatdata_mapping:
+        for p in i.get('paths'):
+            if provider == p.split('/')[0]:
+                return i.get('paths'), i.get('trajects')
+
+def get_data(paths):
+    files = []
+    for p in paths:
+        files.extend(glob.glob(f"{os.getcwd()}/working/{p}/*.json", recursive=True))
+        files.extend(glob.glob(f"{os.getcwd()}/working/{p}/**/*.json", recursive=True))
+    return list(set(files))
+
+def main(opts):
+    data_path = opts.data
+    provider = data_path.split('/')[0]
+    paths, trajects = get_paths_and_trajects(provider)
+    files = get_data(paths)
+
+    # Get fields present in the input file
+    input_fields = []
+    for file in files:
+        with open(file) as f:
+            json_data = json.load(f)
+            for i in json_data:
+                input_fields.extend(list(i.keys()))
+
+    # Get fields mapped in the traject config
+    mapped_fields = []
+    for traject in trajects:
+        with open(f"{os.getcwd()}/../dlme-transform/traject_configs/{traject}") as t:
+            lines = t.readlines()
+            for l in lines:
+                for line in lines:
+                    if "extract_json" in line:
+                        mapped_fields.append(line.split("extract_json('")[-1].split("')")[0].split('[')[0].replace('.', ''))
+
+    with open('traject-validation.txt', 'w') as out:
+        out.write('Fields present in the input files that are not mapped:\n')
+        for i in list(set(input_fields).difference(set(mapped_fields))):
+            out.write('    - '+i+'\n')
+        out.write('\nFields mapped in the traject config that are not present in the input data:\n')
+        for i in list(set(mapped_fields).difference(set(input_fields))):
+            out.write('    - '+i+'\n')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Merge data from a DLME provider harvest as CSV")
+    parser.add_argument('data', help="The same DLME data path passed to the traject config")
+    opts = parser.parse_args()
+
+    main(opts)


### PR DESCRIPTION
Adds a new utility to check that traject configs map all, and only, intended fields by comparing all fields present in the input data with those mapped in the traject config. Writes a report listing unmapped fields and fields the traject file attempts to map that do not exist in the input data.

Updates the Readme.