### PR TITLE
add ucla collections and related post harvest task, fixes #427

### DIFF
--- a/catalogs/ucla.yaml
+++ b/catalogs/ucla.yaml
@@ -1,69 +1,372 @@
 metadata:
   version: 1
   data_path: ucla
+  separate_dags: true
   schedule: "30 13 1 Jan,Apr,Jul,Oct *"
 sources:
-  dupree:
-    description: "Louis Dupree and Nancy Dupree Collection"
-    driver: iiif_json
-    metadata:
-      data_path: ucla/dupree
-      output_format: json
-      config: ucla
-      schedule: "0 1 * * *"
-      fields:
-        body:
-          path: 'items[0]..items..items..body..id'
-          optional: true
-        context:
-          path: '@context'
-          optional: true
-        format:
-          path: 'items[0]..thumbnail..format'
-          optional: true
-        id:
-          path: 'id'
-          optional: true
-        label:
-          path: 'label..none'
-          optional: true
-        thumbnail:
-          path: 'items[0]..thumbnail..id'
-          optional: true
-        type:
-          path: 'items[0]..thumbnail..type'
-          optional: true
-    args:
-      collection_url: https://iiif.library.ucla.edu/collections/ark%3A%2F21198%2Fz16d7kmn?_ga=2.253576201.1800389534.1692626387-126723786.1692626386
   arab_image_foundation:
-    description: "Arab Image Foundation Photo Negatives"
-    driver: iiif_json
+    description: "Arab Image Foundation Photograph Negatives"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:v7h1gc1z-89112
+      wait: 1
+      allow_expiration: true
     metadata:
       data_path: ucla/arab_image_foundation
       output_format: json
       config: ucla
-      schedule: "0 1 * * *"
+      post_harvest: "merge_dataframes"
+      iiif_collection_url: https://iiif.library.ucla.edu/collections/ark%3A%2F21198%2Fz1cg1h7v?_ga=2.148465271.1363753726.1694552417-126723786.1692626386
       fields:
-        body:
-          path: 'items[0]..items..items..body..id'
-          optional: true
-        context:
-          path: '@context'
-          optional: true
-        format:
-          path: 'items[0]..thumbnail..format'
-          optional: true
         id:
-          path: 'id'
+          path: "//dc:identifier[1]"
+          namespace:
+            dc: "http://purl.org/dc/elements/1.1/"
           optional: true
-        label:
-          path: 'label..none'
-          optional: true
-        thumbnail:
-          path: 'items[0]..thumbnail..id'
-          optional: true
-        type:
-          path: 'items[0]..thumbnail..type'
-          optional: true
+  armenian_manuscripts:
+    description: "Armenian Manuscripts"
+    driver: oai_xml
     args:
-      collection_url: https://iiif.library.ucla.edu/collections/ark%3A%2F21198%2Fz1cg1h7v?_ga=2.144982324.1800389534.1692626387-126723786.1692626386
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:d2xg9000zz-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/armenian_manuscripts
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  armenia_collections:
+    description: "Armenia Collections"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:x1s7s81z-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/armenia_collections
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  armenian_massacre:
+    description: "Sachtleben (William) Images of Armenian Massacre"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:054jh200zz-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/armenian_massacre
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  dupree:
+    description: "Louis Dupree and Nancy Dupree Collection"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:nmk7d61z-89112
+      wait: 2
+      allow_expiration: true
+    metadata:
+      data_path: ucla/dupree
+      output_format: json
+      config: ucla
+      post_harvest: "merge_dataframes"
+      iiif_collection_url: https://iiif.library.ucla.edu/collections/ark%3A%2F21198%2Fz16d7kmn?_ga=2.119220809.1363753726.1694552417-126723786.1692626386
+      fields:
+        id:
+          path: "//dc:identifier[1]"
+          namespace:
+            dc: "http://purl.org/dc/elements/1.1/"
+          optional: true
+  egyptology:
+    description: "UCLA Encyclopedia of Egyptology (UEE)"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:d8nwr000zz-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/ucla_egyptology
+      separate_dags: true
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  freidlander_americana:
+    description: "Friedlander (Jonathan) Collection of Middle Eastern Americana, 1875-2006"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:fhgr9000zz-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/freidlander_americana
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  historic_cairo:
+    description: "Historic Cairo Architectural Mapping"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:8k45qj1z-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/historic_cairo
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  iranian_bahai_archives:
+    description: "Iranian National Baha'i Archives"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:fmt5h200zz-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/iranian_bahai_archives
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  green_movement:
+    description: "Green Movement (Iran)"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:txk75c1z-89112
+      wait: 2
+      allow_expiration: true
+    metadata:
+      data_path: ucla/green_movement
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  kirkuk_mosque:
+    description: "Kirkuk’s Great Sufi Mosque"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:wnt7cb1z-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/kirkuk_mosque
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  kurdish_referendum:
+    description: "Kurdish Referendum for Independence"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:k2b9wk1z-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/kurdish_referendum
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  minasian_armenian_collection:
+    description: "Caro Minasian Collection of Armenian Material, circa 1600-1968"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:txkqb200zz-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/minasian_armenian_collection
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  minasian_manuscript_collection:
+    description: "Minasian (Caro) Collection of Persian and Arabic Manuscripts"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:fkmrw000zz-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/minasian_manuscript_collection
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  mosul_lives:
+    description: "Mosul Lives"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:1tc6jf1z-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/mosul_lives
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  near_east_manuscripts:
+    description: "Exhibit Collection of Near Eastern Manuscripts, 1492-1848"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:j4sh8000zz-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/near_east_mss
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  soviet_armenian_posters:
+    description: "Soviet Armenian Posters"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:wv36971z-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/soviet_armenian_posters
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  sulaimani_villages:
+    description: "Villages of Sulaimani (1960-1980)"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:jzg6vc1z-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/sulaimani_villages
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true
+  yazidi_posters:
+    description: "Yazidi Posters"
+    driver: oai_xml
+    args:
+      collection_url: https://digital.library.ucla.edu/catalog/oai
+      metadata_prefix: oai_dc
+      set: member_of_collection_ids_ssim:sqh0kc1z-89112
+      wait: 1
+      allow_expiration: true
+    metadata:
+      data_path: ucla/yazidi_posters
+      output_format: json
+      config: ucla
+      fields:
+        id:
+          path: "//header:identifier"
+          namespace:
+            header: "http://www.openarchives.org/OAI/2.0/"
+          optional: true

--- a/dlme_airflow/tasks/post_harvest.py
+++ b/dlme_airflow/tasks/post_harvest.py
@@ -13,9 +13,13 @@ from dlme_airflow.utils.princeton import (
 from dlme_airflow.utils.qnl import (
     merge_records,
 )
+from dlme_airflow.utils.add_iiif_v3_source import (
+    merge_dataframes,
+)
 from dlme_airflow.utils.yale import (
     remove_babylonian_non_relevant,
 )
+
 
 # The method name/include must match the value in metadata.post_harvest from the catalog
 

--- a/dlme_airflow/utils/add_iiif_v3_source.py
+++ b/dlme_airflow/utils/add_iiif_v3_source.py
@@ -1,0 +1,54 @@
+# /bin/python
+import json
+import os
+import pandas
+import urllib.request
+
+
+def merge_dataframes(**kwargs):
+    """Called by the Airflow workflow to merge multiple data sources for one provider
+    e.g. when the data provider has IIIF and OAI-PMH and one source does not have all
+    of the metadata."""
+    collection = kwargs["collection"]
+    data_file = collection.datafile("json")
+    if os.path.isfile(data_file):
+        df1 = read_datafile_with_lists(data_file)
+        df2 = build_key_value_df(collection.catalog.metadata.get("iiif_collection_url"))
+        df = pandas.merge(df1, df2, on=["id"])
+
+        df.to_json(data_file, orient="records", force_ascii=False)
+
+    return data_file
+
+
+def read_datafile_with_lists(path) -> pandas.DataFrame:
+    """Reads a JSON datafile and returns a Pandas DataFrame after having converted
+    lists serialized as strings back into lists again.
+    """
+    df = pandas.read_json(path)
+    df = df.applymap(lambda v: v if v else None)
+    return df
+
+
+def build_key_value_df(iiif_collection_manifest) -> pandas.DataFrame:
+    """Builds a key/value pair datafram from IIIf v3 thumbnail urls and item manitest urls"""
+    collection = json.loads(urllib.request.urlopen(iiif_collection_manifest).read())
+    data = {}
+    for manifest in collection["items"]:  # IIIF v3
+        if "@id" in manifest:
+            item_manifest_url = manifest["@id"]  # valid in IIIF v2 or v3
+        elif "id" in manifest:
+            item_manifest_url = manifest["id"]  # valid in IIIF v3 only
+
+        item_manifest = json.loads(urllib.request.urlopen(item_manifest_url).read())
+        if "items" in item_manifest:
+            thumbnail_url = item_manifest["items"][0]["thumbnail"][0]["id"]
+
+        data[item_manifest_url] = thumbnail_url
+
+    key_value_df = pandas.DataFrame.from_dict(
+        data, orient="index", columns=["id"]
+    ).reset_index()
+    key_value_df = key_value_df.rename(columns={"index": "item_manifest"})
+
+    return key_value_df

--- a/tests/utils/test_add_iiif_v3_source.py
+++ b/tests/utils/test_add_iiif_v3_source.py
@@ -1,0 +1,73 @@
+import pandas
+import urllib.request
+
+from dlme_airflow.utils.add_iiif_v3_source import (
+    build_key_value_df,
+    read_datafile_with_lists,
+)
+
+
+class MockResponse:
+    @staticmethod
+    def read():
+        return """{
+          "@context": "http://iiif.io/api/presentation/3/context.json",
+          "id": "https://iiif.library.ucla.edu/ark%3A%2F21198%2Fz1qz66ps/manifest",
+          "type": "Manifest",
+          "label": {
+            "none": ["4 Wheeled Cart"]
+          },
+          "items": [{
+            "id": "https://iiif.library.ucla.edu/ark%3A%2F21198%2Fz1qz66ps/manifest/canvas-noc6",
+            "type": "Canvas",
+            "label": {
+              "none": ["4 Wheeled Cart"]
+            },
+            "height": 2830,
+            "width": 4137,
+            "thumbnail": [{
+              "id": "https://iiif.library.ucla.edu/iiif/2/ark%3A%2F21198%2Fz1qz66ps/full/!200,200/0/default.jpg",
+              "type": "Image",
+              "format": "image/jpeg"
+            }],
+            "items": [{
+              "id": "https://iiif.library.ucla.edu/ark%3A%2F21198%2Fz1qz66ps/manifest/canvas-noc6/anno-page-bxqo",
+              "type": "AnnotationPage",
+              "items": [{
+                "id": "https://iiif.library.ucla.edu/ark%3A%2F21198%2Fz1qz66ps/manifest/annotations/anno-oxdb",
+                "type": "Annotation",
+                "motivation": "painting",
+                "body": {
+                  "id": "https://iiif.library.ucla.edu/iiif/2/ark%3A%2F21198%2Fz1qz66ps/full/600,/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/jpeg",
+                  "service": [{
+                    "@id": "https://iiif.library.ucla.edu/iiif/2/ark%3A%2F21198%2Fz1qz66ps",
+                    "@type": "ImageService2",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }]
+                },
+                "target": "https://iiif.library.ucla.edu/ark%3A%2F21198%2Fz1qz66ps/manifest/canvas-noc6"
+              }]
+            }]
+          }]
+        }"""
+
+
+def test_build_key_value_df(monkeypatch):
+    def mock_urlopen(*args, **kwargs):
+        return MockResponse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+
+    result = build_key_value_df("https://fake_iiif_v3_item_manifest_url.com")
+
+    assert "item_manifest" in result.columns
+    assert "id" in result.columns
+    assert len(result.columns) == 2
+
+
+def test_read_datafile_with_lists():
+    df = read_datafile_with_lists("tests/data/json/qnl.json")
+
+    assert isinstance(df, pandas.DataFrame)


### PR DESCRIPTION
I considered several options for implementing this, particularly using the existing drivers for the second data source. I realized, however, that the only case we have for merging two data sources is when one of them is IIIF v3. It would be great to merge IIIF v2 sources with their OAI-PMH counterparts (we have some cases for that) but the IIIF v2 sources lack the thumbnail key which is needed to merge the two data frames. We've never had another case for merging two data sources. So considering that if we used the `iiif_json` driver, we would need to make the catalog considerable more complex (we would double all of the fields, paths, etc.), we would need to modify the drive to look for different data settings, and we would need to modify the tests, its seemed better to contain this in a single post harvest task for now. It should work on all IIIF v3 collections.