### PR TITLE
re-writes json intake driver and adds two collection catalogs

### DIFF
--- a/catalogs/catalog.yaml
+++ b/catalogs/catalog.yaml
@@ -79,10 +79,22 @@ sources:
     description: "Lebanese American University"
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}
+  loc:
+    args:
+      path: catalogs/loc.yaml
+    description: "Library of Congress"
+    driver: intake.catalog.local.YAMLFileCatalog
+    metadata: {}
   manchester:
     args:
       path: catalogs/manchester.yaml
     description: Manchester Uninversity
+    driver: intake.catalog.local.YAMLFileCatalog
+    metadata: {}
+  met:
+    args:
+      path: catalogs/met.yaml
+    description: Met Museum
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}
   newcastle:

--- a/catalogs/loc.yaml
+++ b/catalogs/loc.yaml
@@ -2,59 +2,243 @@ metadata:
   version: 1
   data_path: loc
 sources:
+  abdul-hamid-books:
+    description: "Abdul-Hamid II Books"
+    driver: json
+    args:
+      collection_url: https://www.loc.gov/collections/abdul-hamid-ii-books/?c=100&fo=json
+      nextpage_path: pagination.next
+      collection_selector: "content.results"
+    metadata:
+      data_path: loc/abdul_hamid_books
+      output_format: json
+      config: loc_abdul_hamid_books
+      fields:
+        id:
+          path: "id"
+        description:
+          path: "description"
+        date:
+          path: "date"
+        identifier:
+          path: "shelf_id"
+        language:
+          path: "language"
+        location_country:
+          path: "location_country"
+        format:
+          path: "original_format"
+        part_of:
+          path: "part_of"
+        preview:
+          path: "image_url"
+        shown_at:
+          path: "url"
+        subject:
+          path: "subject"
+        thumbnail:
+          path: 'thumbnail..@id'
+        title:
+          path: "title"
+        type:
+          path: "type"
+  abdul-hamid-photos:
+    description: "Abdul-Hamid II Photos"
+    driver: custom_json
+    args:
+      collection_url: https://www.loc.gov/collections/abdul-hamid-ii/?c=100&fo=json
+      nextpage_path: pagination.next
+      collection_selector: "content.results"
+    metadata:
+      data_path: loc/abdul_hamid_photos
+      output_format: json
+      config: loc_abdul_hamid_photos
+      fields:
+        id:
+          path: "id"
+        description:
+          path: "description"
+        date:
+          path: "date"
+        identifier:
+          path: "shelf_id"
+        language:
+          path: "language"
+        location_country:
+          path: "location_country"
+        format:
+          path: "original_format"
+        part_of:
+          path: "part_of"
+        preview:
+          path: "image_url"
+        shown_at:
+          path: "url"
+        subject:
+          path: "subject"
+        thumbnail:
+          path: 'thumbnail..@id'
+        title:
+          path: "title"
+        type:
+          path: "type"
+  el-taher:
+    description: "El-Taher Collection"
+    driver: custom_json
+    args:
+      collection_url: https://www.loc.gov/collections/eltaher-collection/?c=100&fo=json
+      nextpage_path: pagination.next
+      collection_selector: "content.results"
+    metadata:
+      data_path: loc/el_taher
+      output_format: json
+      config: loc_el_taher
+      fields:
+        id:
+          path: "id"
+        description:
+          path: "description"
+        date:
+          path: "date"
+        identifier:
+          path: "shelf_id"
+        language:
+          path: "language"
+        location_country:
+          path: "location_country"
+        format:
+          path: "original_format"
+        part_of:
+          path: "part_of"
+        preview:
+          path: "image_url"
+        shown_at:
+          path: "url"
+        subject:
+          path: "subject"
+        thumbnail:
+          path: 'thumbnail..@id'
+        title:
+          path: "title"
+        type:
+          path: "type"
+  greek-and-armenian-patriarchates:
+    description: "Greek and Armenian Patriarchates"
+    driver: custom_json
+    args:
+      collection_url: https://www.loc.gov/collections/greek-and-armenian-patriarchates-of-jerusalem/?c=100&fo=json
+      nextpage_path: pagination.next
+      collection_selector: "content.results"
+    metadata:
+      data_path: loc/greek_and_armenian_patriarchates
+      output_format: json
+      config: loc_greek_and_armenian_patriarchates
+      fields:
+        id:
+          path: "id"
+        description:
+          path: "description"
+        date:
+          path: "date"
+        identifier:
+          path: "shelf_id"
+        language:
+          path: "language"
+        location_country:
+          path: "location_country"
+        format:
+          path: "original_format"
+        part_of:
+          path: "part_of"
+        preview:
+          path: "image_url"
+        shown_at:
+          path: "url"
+        subject:
+          path: "subject"
+        thumbnail:
+          path: 'thumbnail..@id'
+        title:
+          path: "title"
+        type:
+          path: "type"
   persian:
     description: "Persian Language Rare Materials"
     driver: custom_json
     args:
       collection_url: https://www.loc.gov/collections/persian-language-rare-materials/?c=100&fo=json
-      csv_kwargs:
-        dtype:
-          call_number: object
-          date: object
-          format: object
-          genre: object
-          language: object
-          medium: object
-          notes: object
-          rights: object
-          source-collection: object
-          subject: object
-          title: object
+      nextpage_path: pagination.next
+      collection_selector: "content.results"
     metadata:
-      record_selector: "content.results"
       data_path: loc/persian
-      config: loc
+      output_format: json
+      config: loc_persian
       fields:
-        call_number:
-          path: "item.call_number[0]"
-          optional: true
-        date:
-          path: "item.date"
-          optional: true
-        format:
-          path: "item.format"
-          optional: true
-        language:
-          path: "item.language"
-          optional: true
-        medium:
-          path: "item.medium"
-          optional: true
-        notes:
-          path: "item.notes"
-          opional: true
-        subject:
-          path: "item.subjects"
-          optional: true
-        title:
-          path: "item.title"
         id:
           path: "id"
         description:
           path: "description"
-          optional: true
-        rendering:
-          path: "resources[0].url"
+        date:
+          path: "date"
+        identifier:
+          path: "shelf_id"
+        language:
+          path: "language"
+        location_country:
+          path: "location_country"
+        format:
+          path: "original_format"
+        part_of:
+          path: "part_of"
+        preview:
+          path: "image_url"
+        shown_at:
+          path: "url"
+        subject:
+          path: "subject"
         thumbnail:
-          path: "resources[0].image"
-          optional: true
+          path: 'thumbnail..@id'
+        title:
+          path: "title"
+        type:
+          path: "type"
+  st-catherines:
+    description: "St. Catherine's Monastery"
+    driver: custom_json
+    args:
+      collection_url: https://www.loc.gov/collections/manuscripts-in-st-catherines-monastery-mount-sinai/?c=100&fo=json
+      nextpage_path: pagination.next
+      collection_selector: "content.results"
+    metadata:
+      data_path: loc/st_catherines
+      output_format: json
+      config: loc_st_catherines
+      fields:
+        id:
+          path: "id"
+        description:
+          path: "description"
+        date:
+          path: "date"
+        identifier:
+          path: "shelf_id"
+        language:
+          path: "language"
+        location_country:
+          path: "location_country"
+        format:
+          path: "original_format"
+        part_of:
+          path: "part_of"
+        preview:
+          path: "image_url"
+        shown_at:
+          path: "url"
+        subject:
+          path: "subject"
+        thumbnail:
+          path: 'thumbnail..@id'
+        title:
+          path: "title"
+        type:
+          path: "type"

--- a/catalogs/met.yaml
+++ b/catalogs/met.yaml
@@ -1,0 +1,80 @@
+metadata:
+  version: 1
+  data_path: met
+sources:
+  egyptian:
+    description: "Near East"
+    driver: custom_json
+    args:
+      collection_url: https://metmuseum.org/api/collection/collectionlisting?department=10&showOnly=openAccess&perPage=100&offset=100
+      increment:
+        variable_string: offset=
+        amount: "100"
+      collection_selector: results
+      result_count:
+        path: "totalResults"
+    metadata:
+      data_path: met/egyptian
+      output_format: json
+      config: met
+      fields:
+        id:
+          path: "id"
+        artist:
+          path: "artist"
+        culture:
+          path: "culture"
+        description:
+          path: "description"
+        date:
+          path: "date"
+        identifier:
+          path: "accessionNumber"
+        medium:
+          path: "medium"
+        shown_at:
+          path: "url"
+        thumbnail:
+          path: "image"
+        title:
+          path: "title"
+        teaser_text:
+          path: "teaserText"
+  near-east:
+    description: "Near East"
+    driver: custom_json
+    args:
+      collection_url: https://metmuseum.org/api/collection/collectionlisting?department=3&showOnly=openAccess&perPage=100&offset=100
+      increment:
+        variable_string: offset=
+        amount: "100"
+      collection_selector: results
+      result_count:
+        path: "totalResults"
+    metadata:
+      data_path: met/near_east
+      output_format: json
+      config: met
+      fields:
+        id:
+          path: "id"
+        artist:
+          path: "artist"
+        culture:
+          path: "culture"
+        description:
+          path: "description"
+        date:
+          path: "date"
+        identifier:
+          path: "accessionNumber"
+        medium:
+          path: "medium"
+        shown_at:
+          path: "url"
+        thumbnail:
+          path: "image"
+        title:
+          path: "title"
+        teaser_text:
+          path: "teaserText"

--- a/dlme_airflow/drivers/json.py
+++ b/dlme_airflow/drivers/json.py
@@ -1,155 +1,246 @@
+import time
 import logging
+import intake
 import requests
 import jsonpath_ng
+import pandas as pd
+from typing import Any, Optional, Generator
 
-from pandas import DataFrame
-from intake.source.base import DataSource, Schema
+
+container = "dataframe"
+name = "custom_json"
+version = "0.0.1"
+partition_access = True
 
 
-class JsonSource(DataSource):
-    """
-    JsonSource lets you configure your Intake catalog entry with JSONPath
-    expressions that populate the resulting Pandas DataFrame.
-    See https://github.com/h2non/jsonpath-ng#jsonpath-syntax for what constitues a valid JSONPath.
-
-    For example if your Intake catalog contains:
-
-        args:
-            collection_url: https://www.loc.gov/collections/persian-language-rare-materials/?c=100&fo=json
-        metadata:
-          record_selector: "content.results"
-          fields:
-            id:
-              path: "id",
-            title:
-              path: "title"
-            thumbnail:
-              path: "resources[0].image"
-
-    and the collection URL returns JSON that looks like:
-
-    {
-      "content": {
-        "results": [
-          {
-            "id": "http://www.loc.gov/item/2017498321/",
-            "title": "[Majmuʻah, or, Collection]",
-            "resources": [
-              "image": "https://tile.loc.gov/image-services/iiif/service:amed:plmp:m154:0334/full/pct:6.25/0/default.jpg"
-            ]
-          },
-          {
-            "id": "http://www.loc.gov/item/00313408/",
-            "title": "Sakīnat al-fuz̤alāʼ mawsūm bi-ism-i tārīkhī-i Bahār-i Afghānī",
-            "resources": [
-              "image": "https://tile.loc.gov/image-services/iiif/service:amed:amedpllc:00406537456:0055/full/pct:6.25/0/default.jpg"
-            ]
-          }
-        ]
-      }
-    }
-
-    You would end up with a CSV with three columns (id, title and thumbnail) and two rows.
-    """
-
-    container = "dataframe"
-    name = "custom_json"
-    version = "0.0.1"
-    partition_access = True
-
-    def __init__(self, collection_url, metadata={}, csv_kwargs={}):
+class JsonSource(intake.source.base.DataSource):
+    def __init__(
+        self,
+        collection_url,
+        nextpage_path=None,
+        increment=None,
+        result_count=None,
+        collection_selector=None,
+        dtype=None,
+        metadata=None,
+        wait=None,
+    ):
         super(JsonSource, self).__init__(metadata=metadata)
         self.collection_url = collection_url
-        self.metadata = metadata
-        self.csv_kwargs = csv_kwargs
-        self._setup_json_paths()
+        self.nextpage_path = nextpage_path
+        self.increment = increment
+        self.result_count = result_count
+        self.collection_selector = collection_selector
+        self.dtype = dtype
+        self.wait = wait
+        self._page_urls = []
+        self._path_expressions = {}
+        self.record_count = 0
+        self.record_limit = self.metadata.get("record_limit")
 
-    def read(self) -> DataFrame:
-        self._load_metadata()
-        df = self._get_dataframe()
-        return df
+    def _open_collection(self):
+        # either the API passes the next page or we increment with a url pattern
+        if self.nextpage_path:
+            self._page_urls.append(self.collection_url)
+            logging.info(f"getting collection {self.collection_url}")
+            resp = self._get(self.collection_url)
+            if resp.status_code == 200:
+                collection_result = resp.json()
+                expression = jsonpath_ng.parse(self.nextpage_path)
+                if [match.value for match in expression.find(collection_result)]:
+                    next = [
+                        match.value for match in expression.find(collection_result)
+                    ][0]
+                    while next:
+                        self._page_urls.append(next)
 
-    def _get_schema(self) -> Schema:
-        return Schema(
+                        resp = self._get(next)
+                        if resp.status_code == 200:
+                            result = resp.json()
+                            next = [match.value for match in expression.find(result)][0]
+                        else:
+                            logging.error(
+                                f"got {resp.status_code} when fetching {next}"
+                            )
+                else:
+                    raise Exception(
+                        f"Pagination path not found in: {self.collection_url}"
+                    )
+            else:
+                logging.error(
+                    f"got {resp.status_code} when fetching {self.collection_url}"
+                )
+        else:
+            self._page_urls.append(self.collection_url)
+            logging.info(f"getting collection {self.collection_url}")
+            # pass a json path for the result count in the catalog or hard code the count
+            if self.result_count:
+                if self.result_count.get("path"):
+                    resp = self._get(self.collection_url)
+                    if resp.status_code == 200:
+                        collection_result = resp.json()
+                        expression = jsonpath_ng.parse(self.result_count.get("path"))
+
+                        if [
+                            match.value for match in expression.find(collection_result)
+                        ]:
+                            result_count = [
+                                match.value
+                                for match in expression.find(collection_result)
+                            ][0]
+                else:
+                    try:
+                        result_count = int(self.result_count.get("count"))
+                    except result_count.does_not_exist:
+                        logging.error(
+                            "result_count needs to be set in the catalog with a json path or a hard coded number"
+                        )
+            url = self.collection_url
+            if self.increment:
+                start = int(self.increment.get("amount"))
+                for i in range(
+                    int(self.increment.get("amount")),
+                    result_count,
+                    int(self.increment.get("amount")),
+                ):
+                    url = url.replace(
+                        f"{self.increment.get('variable_string')}{start}",
+                        f"{self.increment.get('variable_string')}{start+int(self.increment.get('amount'))}",
+                    )
+                    start += int(self.increment.get("amount"))
+                    self._page_urls.append(url)
+            else:
+                logging.error("increment key not found in catalog")
+
+    def _open_page(self, page_url: str) -> Optional[list]:
+        logging.info(f"getting page {page_url}")
+        resp = self._get(page_url)
+        if resp.status_code == 200:
+            page_result = resp.json()
+            expression = jsonpath_ng.parse(self.collection_selector)
+            page_result = _flatten_list(
+                [match.value for match in expression.find(page_result)]
+            )
+        else:
+            logging.error(f"got {resp.status_code} when fetching manifest {page_url}")
+            return None
+        records = [self._extract_specified_fields(record) for record in page_result]
+        for record in records:
+            record.update(self._extract_record_metadata(record.get("metadata", [])))
+        return records
+
+    def _extract_specified_fields(self, json_page_result: dict) -> dict:
+        output: dict[str, Any] = {}
+        for name, info in self.metadata.get("fields").items():
+            expression = self._path_expressions.get(name)
+            result = [match.value for match in expression.find(json_page_result)]
+            if (
+                len(result) < 1
+            ):  # the JSONPath expression didn't find anything in the manifest
+                if info.get("optional") is True:
+                    logging.debug(
+                        f"{json_page_result} missing optional field: '{name}'; searched path: '{expression}'"
+                    )
+                else:
+                    logging.warning(
+                        f"{json_page_result} missing required field: '{name}'; searched path: '{expression}'"
+                    )
+            else:
+                if (
+                    len(result) == 1
+                ):  # the JSONPath expression found exactly one result in the manifest
+                    output[name] = _stringify_and_strip_if_list(result[0])
+                else:  # the JSONPath expression found exactly one result in the manifest
+                    if name not in output:
+                        output[name] = []
+
+                    for data in result:
+                        output[name].append(_stringify_and_strip_if_list(data))
+        return output
+
+    def _extract_record_metadata(self, record_metadata) -> dict[str, list[str]]:
+        output: dict[str, list[str]] = {}
+        for row in record_metadata:
+            name = (
+                row.get("label")
+                .replace(" ", "-")
+                .lower()
+                .replace("(", "")
+                .replace(")", "")
+            )
+            # initialize or append to output[name] based on whether we've seen the label
+            metadata_value = row.get("value")
+            if not metadata_value:
+                continue
+
+            if isinstance(metadata_value[0], dict):
+                metadata_value = metadata_value[0].get("@value")
+
+            if name in output:
+                output[name].append(metadata_value)
+            else:
+                output[name] = [metadata_value]
+
+        # flatten any nested lists into a single list
+        return {k: list(_flatten_list(v)) for (k, v) in output.items()}
+
+    def _get_partition(self, i) -> pd.DataFrame:
+        # if we are over the defined limit return an empty DataFrame right away
+        if self.record_limit is not None and self.record_count > self.record_limit:
+            return pd.DataFrame()
+
+        result = self._open_page(self._page_urls[i])
+
+        # If the dictionary has AT LEAST one value that is not None return a
+        # DataFrame with the keys as columns, and the values as a row.
+        # Otherwise return an empty DataFrame that can be concatenated.
+        # This will prevent rows with all empty values from being generated
+        # For context see https://github.com/sul-dlss/dlme-airflow/issues/192
+
+        if result is not None and len(result) > 0:
+            self.record_count = len(result)
+            return pd.DataFrame(result)
+        else:
+            logging.warning(f"{self._page_urls[i]} resulted in empty DataFrame")
+            return pd.DataFrame()
+
+    def _get_schema(self):
+        for name, info in self.metadata.get("fields", {}).items():
+            self._path_expressions[name] = jsonpath_ng.parse(info.get("path"))
+        self._open_collection()
+        return intake.source.base.Schema(
             datashape=None,
-            dtype=self.csv_kwargs.get("dtype"),
+            dtype=self.dtype,
             shape=None,
-            npartitions=1,
+            npartitions=len(self._page_urls),
+            extra_metadata={},
         )
 
-    def _get_dataframe(self) -> DataFrame:
-        resp = requests.get(self.collection_url)
-        if resp.status_code != 200:
-            raise Exception(
-                f"HTTP request for {self.collection_url} resulted in {resp.status_code}"
-            )
-        return self._process_json(resp.json())
+    def _get(self, url):
+        if self.wait:
+            logging.info(f"waiting {self.wait} seconds")
+            time.sleep(self.wait)
+        return requests.get(url)
 
-    def _process_json(self, data) -> list:
-        # record_selector usually identifies a single list, but it could
-        # identify more than one if the jsonpath allows for that
-        record_containers = self.record_selector.find(data)
-        if len(record_containers) == 0:
-            logging.warn(
-                f"Couldn't find records selector: {self.record_selector.expression}"
-            )
-            return []
+    def read(self):
+        self._load_metadata()
+        df = pd.concat([self.read_partition(i) for i in range(self.npartitions)])
+        if self.record_limit:
+            return df.head(self.record_limit)
+        else:
+            return df
 
-        objects = []
-        for record_container in record_containers:
-            for rec in record_container.value:
-                obj = {}
-                for field in self.field_paths:
-                    path = field["path"]
-                    name = field["name"]
-                    result = path.find(rec)
-                    if len(result) == 1:
-                        obj[name] = result[0].value
-                    elif len(result) > 1:
-                        obj[name] = [m.value for m in result]
-                    elif not field["optional"]:
-                        logging.warn(f"{name} is not optional")
-                objects.append(obj)
 
-        return DataFrame(objects)
+def _stringify_and_strip_if_list(possible_list) -> list[str]:
+    if isinstance(possible_list, list):
+        return [str(elt).strip() for elt in possible_list]
+    else:
+        return possible_list
 
-    def _setup_json_paths(self):
-        # get the record selector and parse it
-        path = self.metadata.get("record_selector")
-        if path is None:
-            raise Exception("JsonSource metadata must define a record_selector")
-        try:
-            self.record_selector = jsonpath_ng.parse(path)
-        except Exception as e:
-            raise Exception(f"Invalid JSONPath record_selector {path}: {e}")
 
-        # get the mapping of field names to jsonpaths
-        fields = self.metadata.get("fields")
-        if fields is None or type(fields) is not dict:
-            raise Exception("JsonSource metadata must define fields as an object")
-
-        self.field_paths = []
-        for field_name, field_info in fields.items():
-            if type(field_info) != dict:
-                raise Exception(
-                    f"The value for metadata field {field_name} must be an object"
-                )
-
-            path = field_info.get("path")
-            if path is None:
-                raise Exception(f"The metadata field {field_name} must define a path")
-
-            try:
-                path = jsonpath_ng.parse(path)
-            except Exception as e:
-                raise Exception(f"Invalid {field_name} JSONPath {path}: {e}")
-
-            self.field_paths.append(
-                {
-                    "name": field_name,
-                    "path": path,
-                    "optional": field_info.get("optional"),
-                }
-            )
-
-        logging.info(f"Found jsonpaths: {self.field_paths}")
+def _flatten_list(lst: list) -> Generator:
+    for item in lst:
+        if type(item) == list:
+            yield from _flatten_list(item)
+        else:
+            yield item

--- a/tests/drivers/test_json.py
+++ b/tests/drivers/test_json.py
@@ -11,14 +11,19 @@ def test_happy_path(requests_mock):
         json=loc_data,
     )
 
+    # the collection selector json path defined in the Intake catalog
+    collection_selector = "content.results"
+
     # the collection url defined in the Intake catalog
     collection_url = (
         "https://www.loc.gov/collections/persian-language-rare-materials/?c=100&fo=json"
     )
 
+    # the nextpage json path defined in the Intake catalog
+    nextpage_path = "pagination.next"
+
     # this jsonpath configuration is required in the intake catalog
     metadata = {
-        "record_selector": "content.results",
         "fields": {
             "id": {"path": "id"},
             "title": {"path": "title"},
@@ -30,7 +35,12 @@ def test_happy_path(requests_mock):
     }
 
     # create our JsonSource object
-    js = JsonSource(collection_url, metadata=metadata)
+    js = JsonSource(
+        collection_url,
+        collection_selector=collection_selector,
+        nextpage_path=nextpage_path,
+        metadata=metadata,
+    )
 
     # get the DataFrame
     df = js.read()


### PR DESCRIPTION
The existing json driver was written for the Library of Congress data but it doesn't handle paging so it could not be used for that collection or any other. This driver handles paging by accepting a json path in the catolog to the next page or by iterating through the results and updating offset in the url.