### PR TITLE
Refactor paging into PartitionBuilder

### DIFF
--- a/catalogs/brooklyn.yaml
+++ b/catalogs/brooklyn.yaml
@@ -1,0 +1,34 @@
+metadata:
+  version: 1
+  data_path: brooklyn
+sources:
+  near-east-egyptian:
+    description: "Near east and Egyptian"
+    driver: custom_json
+    args:
+      collection_url: https://www.brooklynmuseum.org/api/v2/object/
+      paging:
+        pages_url: https://www.brooklynmuseum.org/api/v2/collection/5/object
+        urls: data.id
+        limit: 25
+      record_selector: "data"
+      api_key: "0IzFpBiUksT8LMVGLUxovj9IR0ltlSH1"
+    metadata:
+      data_path: brooklyn/near-east-egyptian
+      output_format: json
+      config: brooklyn_near_east_egyptian
+      fields:
+        id:
+          path: "id"
+        description:
+          path: "description"
+        date:
+          path: "date_added"
+        preview:
+          path: "primary_image"
+        shown_at:
+          path: "primary_image"
+        subject:
+          path: "classification"
+        title:
+          path: "title"

--- a/catalogs/catalog.yaml
+++ b/catalogs/catalog.yaml
@@ -37,6 +37,12 @@ sources:
     description: "Bodleian Libraries, University of Oxford"
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}
+  brooklyn:
+    args:
+      path: catalogs/brooklyn.yaml
+    description: "Brooklyn Near East and Egyptian collection"
+    driver: intake.catalog.local.YAMLFileCatalog
+    metadata: {}
   cambridge:
     args:
       path: catalogs/cambridge.yaml

--- a/catalogs/loc.yaml
+++ b/catalogs/loc.yaml
@@ -4,10 +4,11 @@ metadata:
 sources:
   abdul-hamid-books:
     description: "Abdul-Hamid II Books"
-    driver: json
+    driver: custom_json
     args:
       collection_url: https://www.loc.gov/collections/abdul-hamid-ii-books/?c=100&fo=json
-      nextpage_path: pagination.next
+      paging:
+        urls: pagination.page_list
       record_selector: "content.results"
     metadata:
       data_path: loc/abdul_hamid_books
@@ -47,7 +48,8 @@ sources:
     driver: custom_json
     args:
       collection_url: https://www.loc.gov/collections/abdul-hamid-ii/?c=100&fo=json
-      nextpage_path: pagination.next
+      paging:
+        urls: pagination.page_list
       record_selector: "content.results"
     metadata:
       data_path: loc/abdul_hamid_photos
@@ -87,7 +89,8 @@ sources:
     driver: custom_json
     args:
       collection_url: https://www.loc.gov/collections/eltaher-collection/?c=100&fo=json
-      nextpage_path: pagination.next
+      paging:
+        urls: pagination.page_list
       record_selector: "content.results"
     metadata:
       data_path: loc/el_taher
@@ -127,7 +130,8 @@ sources:
     driver: custom_json
     args:
       collection_url: https://www.loc.gov/collections/greek-and-armenian-patriarchates-of-jerusalem/?c=100&fo=json
-      nextpage_path: pagination.next
+      paging:
+        urls: pagination.page_list
       record_selector: "content.results"
     metadata:
       data_path: loc/greek_and_armenian_patriarchates
@@ -167,7 +171,8 @@ sources:
     driver: custom_json
     args:
       collection_url: https://www.loc.gov/collections/persian-language-rare-materials/?c=100&fo=json
-      nextpage_path: pagination.next
+      paging:
+        urls: pagination.page_list
       record_selector: "content.results"
     metadata:
       data_path: loc/persian
@@ -207,7 +212,8 @@ sources:
     driver: custom_json
     args:
       collection_url: https://www.loc.gov/collections/manuscripts-in-st-catherines-monastery-mount-sinai/?c=100&fo=json
-      nextpage_path: pagination.next
+      paging:
+        urls: pagination.page_list
       record_selector: "content.results"
     metadata:
       data_path: loc/st_catherines

--- a/catalogs/met.yaml
+++ b/catalogs/met.yaml
@@ -6,13 +6,12 @@ sources:
     description: "Near East"
     driver: custom_json
     args:
-      collection_url: https://metmuseum.org/api/collection/collectionlisting?department=10&showOnly=openAccess&perPage=100&offset=100
-      increment:
-        variable_string: offset=
-        amount: "100"
+      collection_url: https://metmuseum.org/api/collection/collectionlisting?department=10&showOnly=openAccess&perPage=100
+      paging:
+        increment: 100
+        query_param: offset
+        result_count: "totalResults"
       record_selector: results
-      result_count:
-        path: "totalResults"
     metadata:
       data_path: met/egyptian
       output_format: json
@@ -44,13 +43,12 @@ sources:
     description: "Near East"
     driver: custom_json
     args:
-      collection_url: https://metmuseum.org/api/collection/collectionlisting?department=3&showOnly=openAccess&perPage=100&offset=100
-      increment:
-        variable_string: offset=
-        amount: "100"
+      collection_url: https://metmuseum.org/api/collection/collectionlisting?department=3&showOnly=openAccess&perPage=100
+      paging:
+        increment: 100
+        query_param: offset
+        result_count: "totalResults"
       record_selector: results
-      result_count:
-        path: "totalResults"
     metadata:
       data_path: met/near_east
       output_format: json

--- a/dlme_airflow/drivers/json.py
+++ b/dlme_airflow/drivers/json.py
@@ -44,7 +44,9 @@ class JsonSource(intake.source.base.DataSource):
         # either the API passes the next page or we increment with a url pattern
         self._page_urls.append(self.collection_url)
         if self.paging:
-            self._page_urls = PartitionBuilder(self.collection_url, self.paging, self.api_key).urls()
+            self._page_urls = PartitionBuilder(
+                self.collection_url, self.paging, self.api_key
+            ).urls()
 
     def _open_page(self, page_url: str) -> Optional[list]:
         resp = self._get(page_url)
@@ -157,7 +159,7 @@ class JsonSource(intake.source.base.DataSource):
         if self.wait:
             logging.info(f"waiting {self.wait} seconds")
             time.sleep(self.wait)
-        return requests.get(url, headers = headers)
+        return requests.get(url, headers=headers)
 
     def read(self):
         self._load_metadata()

--- a/dlme_airflow/utils/partition_url_builder.py
+++ b/dlme_airflow/utils/partition_url_builder.py
@@ -6,6 +6,7 @@ class PartitionBuilder:
     """Determine the method used to extract or format the
     page queries when provider API requires paging.
     """
+
     def __init__(
         self,
         collection_url,
@@ -27,7 +28,7 @@ class PartitionBuilder:
             return self._calculate_partitions()
         elif self.paging_config.get("urls"):
             return self._urls_from_provider()
-        
+
         return []
 
     def _urls_from_provider(self):
@@ -41,7 +42,7 @@ class PartitionBuilder:
             for next in page_urls:
                 if next["url"]:
                     urls.append(next["url"])
-        
+
         return urls
 
     def _calculate_partitions(self):
@@ -53,26 +54,25 @@ class PartitionBuilder:
         while offset < record_count:
             urls.append(f"{self.collection_url}&offset={offset}")
             offset += increment
-        
+
         return urls
 
     def _prefetch_page_urls(self):
         offset = 0
         harvested = 0
-        records = 0
         ids = []
         while True:
-            api_endpoint = f"{self.paging_config['pages_url']}?limit={self.paging_config['limit']}&offset={offset}" 
-            data = self._fetch_provider_data(api_endpoint)['data']
-            offset+=self.paging_config['limit']
-            harvested=len(data)
+            api_endpoint = f"{self.paging_config['pages_url']}?limit={self.paging_config['limit']}&offset={offset}"
+            data = self._fetch_provider_data(api_endpoint)["data"]
+            offset += self.paging_config["limit"]
+            harvested = len(data)
 
             for i in data:
                 ids.append(f"{self.collection_url}{i['id']}")
 
-            if harvested < self.paging_config['limit']:
+            if harvested < self.paging_config["limit"]:
                 break
-        
+
         return ids
 
     def _fetch_provider_data(self, url):
@@ -80,6 +80,6 @@ class PartitionBuilder:
         if self.api_key:
             headers["api_key"] = self.api_key
 
-        resp = requests.get(url, headers = headers)
+        resp = requests.get(url, headers=headers)
         if resp.status_code == 200:
             return resp.json()

--- a/dlme_airflow/utils/partition_url_builder.py
+++ b/dlme_airflow/utils/partition_url_builder.py
@@ -3,27 +3,35 @@ import jsonpath_ng
 
 
 class PartitionBuilder:
+    """Determine the method used to extract or format the
+    page queries when provider API requires paging.
+    """
     def __init__(
         self,
         collection_url,
         paging_config,
+        api_key=None,
     ):
         self.collection_url = collection_url
         self.paging_config = paging_config
         self.provider_data = None
-        self.partition_urls = [collection_url]
+        self.api_key = api_key
 
     def urls(self):
-        self.provider_data = self._fetch_provider_data()
+        # self.provider_data = self._fetch_provider_data()
+        if self.paging_config.get("pages_url"):
+            return self._prefetch_page_urls()
 
-        if self.paging_config.get("urls"):
-            self._urls_from_provider()
-        elif self.paging_config.get("increment"):
-            self._calculate_partitions()
-
-        return self.partition_urls
+        self.provider_data = self._fetch_provider_data(self.collection_url)
+        if self.paging_config.get("increment"):
+            return self._calculate_partitions()
+        elif self.paging_config.get("urls"):
+            return self._urls_from_provider()
+        
+        return []
 
     def _urls_from_provider(self):
+        urls = [self.collection_url]
         expression = jsonpath_ng.parse(self.paging_config["urls"])
         for match in expression.find(self.provider_data):
             if [match.value for match in expression.find(self.provider_data)]:
@@ -32,18 +40,46 @@ class PartitionBuilder:
                 ][0]
             for next in page_urls:
                 if next["url"]:
-                    self.partition_urls.append(next["url"])
+                    urls.append(next["url"])
+        
+        return urls
 
     def _calculate_partitions(self):
+        urls = [self.collection_url]
         increment = offset = self.paging_config["increment"]
         expression = jsonpath_ng.parse(self.paging_config["result_count"])
         record_count = expression.find(self.provider_data)[0].value
 
         while offset < record_count:
-            self.partition_urls.append(f"{self.collection_url}&offset={offset}")
+            urls.append(f"{self.collection_url}&offset={offset}")
             offset += increment
+        
+        return urls
 
-    def _fetch_provider_data(self):
-        resp = requests.get(self.collection_url)
+    def _prefetch_page_urls(self):
+        offset = 0
+        harvested = 0
+        records = 0
+        ids = []
+        while True:
+            api_endpoint = f"{self.paging_config['pages_url']}?limit={self.paging_config['limit']}&offset={offset}" 
+            data = self._fetch_provider_data(api_endpoint)['data']
+            offset+=self.paging_config['limit']
+            harvested=len(data)
+
+            for i in data:
+                ids.append(f"{self.collection_url}{i['id']}")
+
+            if harvested < self.paging_config['limit']:
+                break
+        
+        return ids
+
+    def _fetch_provider_data(self, url):
+        headers = {}
+        if self.api_key:
+            headers["api_key"] = self.api_key
+
+        resp = requests.get(url, headers = headers)
         if resp.status_code == 200:
             return resp.json()

--- a/dlme_airflow/utils/partition_url_builder.py
+++ b/dlme_airflow/utils/partition_url_builder.py
@@ -1,0 +1,49 @@
+import requests
+import jsonpath_ng
+
+
+class PartitionBuilder:
+    def __init__(
+        self,
+        collection_url,
+        paging_config,
+    ):
+        self.collection_url = collection_url
+        self.paging_config = paging_config
+        self.provider_data = None
+        self.partition_urls = [collection_url]
+
+    def urls(self):
+        self.provider_data = self._fetch_provider_data()
+
+        if self.paging_config.get("urls"):
+            self._urls_from_provider()
+        elif self.paging_config.get("increment"):
+            self._calculate_partitions()
+
+        return self.partition_urls
+
+    def _urls_from_provider(self):
+        expression = jsonpath_ng.parse(self.paging_config["urls"])
+        for match in expression.find(self.provider_data):
+            if [match.value for match in expression.find(self.provider_data)]:
+                page_urls = [
+                    match.value for match in expression.find(self.provider_data)
+                ][0]
+            for next in page_urls:
+                if next["url"]:
+                    self.partition_urls.append(next["url"])
+
+    def _calculate_partitions(self):
+        increment = offset = self.paging_config["increment"]
+        expression = jsonpath_ng.parse(self.paging_config["result_count"])
+        record_count = expression.find(self.provider_data)[0].value
+
+        while offset < record_count:
+            self.partition_urls.append(f"{self.collection_url}&offset={offset}")
+            offset += increment
+
+    def _fetch_provider_data(self):
+        resp = requests.get(self.collection_url)
+        if resp.status_code == 200:
+            return resp.json()

--- a/tests/data/json/loc.json
+++ b/tests/data/json/loc.json
@@ -33114,18 +33114,6 @@
       {
         "number": 1,
         "url": null
-      },
-      {
-        "number": 2,
-        "url": "https://www.loc.gov/collections/persian-language-rare-materials/?c=100&fo=json&sp=2"
-      },
-      {
-        "number": 3,
-        "url": "https://www.loc.gov/collections/persian-language-rare-materials/?c=100&fo=json&sp=3"
-      },
-      {
-        "number": "...",
-        "url": "https://www.loc.gov/collections/persian-language-rare-materials/?c=100&fo=json&sp=4"
       }
     ],
     "perpage": 100,

--- a/tests/drivers/test_json.py
+++ b/tests/drivers/test_json.py
@@ -36,6 +36,7 @@ def test_happy_path(requests_mock):
         collection_url,
         record_selector=record_selector,
         metadata=metadata,
+        paging={"urls": "pagination.page_list"},
     )
 
     # get the DataFrame

--- a/tests/support/schemas/schema.yaml
+++ b/tests/support/schemas/schema.yaml
@@ -22,6 +22,7 @@ properties:
           type: string
           enum:
             - csv
+            - custom_json
             - json
             - iiif_json
             - oai_xml


### PR DESCRIPTION
This is a spike on simplifying the complexity of paged JSON content - this should eventually provide a "partition url builder" class so that the majority of the json driver is reusable in order to avoid duplication across vendor specific drivers.