### PR TITLE
Prevent pandas data type inference

### DIFF
--- a/dlme_airflow/utils/read_df.py
+++ b/dlme_airflow/utils/read_df.py
@@ -6,6 +6,8 @@ def read_datafile_with_lists(path) -> pandas.DataFrame:
     """Reads a JSON datafile and returns a Pandas DataFrame after having converted
     lists serialized as strings back into lists again.
     """
-    df = pandas.read_json(path)
+    # the options turn off pandas trying to helpfully convert datatypes and dates
+    # see: https://github.com/sul-dlss/dlme-airflow/issues/482
+    df = pandas.read_json(path, convert_dates=False, dtype=False)
     df = df.applymap(lambda v: v if v else None)
     return df

--- a/tests/utils/test_read_df.py
+++ b/tests/utils/test_read_df.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import tempfile
 
 from dlme_airflow.utils.read_df import read_datafile_with_lists
 
@@ -10,3 +11,13 @@ def test_read_datafile_with_lists():
     assert isinstance(df2, pd.DataFrame)
     assert df1.shape == df2.shape
     assert isinstance(df2["ObjectName"].values[0], str)
+
+
+def test_date():
+    with tempfile.NamedTemporaryFile() as fh:
+        json_path = fh.name
+        df1 = pd.DataFrame({"id": [1, 2], "date": ["1910", "2014"]})
+        df1.to_json(json_path)
+
+        df2 = read_datafile_with_lists(json_path)
+        assert df2.iloc[0]["date"] == "1910"


### PR DESCRIPTION
When reading JSON data back into Pandas we have to be careful not to let Pandas infer types or else a column named 'date' with a string '1960' in it will get parsed as a datetime, which then causes it to be persisted incorrectly.

I added [a test](https://github.com/sul-dlss/dlme-airflow/blob/41052ecd64a79ed5259f3f5c5f46fb24c9f1729f/tests/utils/test_read_df.py#L16-L23) that initially failed, until I made the correction to how JSON is read in.

Fixes #482
