### PR TITLE
Remove far out of date docker-socat for local build

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+RUN apk --update add socat
+
+ENTRYPOINT ["socat"]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -147,7 +147,9 @@ services:
       _AIRFLOW_WWW_USER_PASSWORD: ${_AIRFLOW_WWW_USER_PASSWORD:-airflow}
 
   docker-proxy:
-    image: bobrik/socat
+    image: suldlss/airflow-proxy:latest
+    build:
+      dockerfile: Dockerfile.proxy
     command: "TCP4-LISTEN:2375,fork,reuseaddr UNIX-CONNECT:/var/run/docker.sock"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -165,7 +165,9 @@ services:
       retries: 5
 
   docker-proxy:
-    image: bobrik/socat
+    image: suldlss/airflow-proxy:latest
+    build:
+      dockerfile: Dockerfile.proxy
     command: "TCP4-LISTEN:2375,fork,reuseaddr UNIX-CONNECT:/var/run/docker.sock"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
I have been unable to start dlme-airflow on my local machine since getting the updated laptop, After some debugging, I discovered that this image we're using to proxy through docker for file system needs no longer works properly as it's 9 years old and it's base image is deprecated.

This removes the dependency on an external image and build a local image based on `bobrik/docker-socat` but uses `alpine:latest`.