### PR TITLE
Changes for uv and bin scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,13 +250,13 @@ voice_of_america:
 
 Sometimes it can be useful to be able to fetch data from a provider on the command line. This can be useful when adding or modifying a catalog entry, developing a driver, or when working with the data that is collected. To aid in that the `bin/get` utility will fetch data from a provider/collection and output the collected CSV to stdout or to a file.
 
-First you'll want to enter the poetry virtual environment:
+First you will want to activate your virtual environment with:
 
 ```
-$ poetry shell
+$ source .venv/bin/activate
 ```
 
-and then run `bin/get` with a provider and collection as arguments (optionally you can write to a file with `--output`, or aboart the harvest early with `--limit`):
+Then run `bin/get` with a provider and collection as arguments (optionally you can write to a file with `--output`, or abort the harvest early with `--limit`):
 
 ```
 $ bin/get yale babylonian --limit 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
 
 [project]
-name = "dlme-airflow"
+name = "dlme_airflow"
 version = "0.1.0"
 description = "ETL Pipeline management for the Digital Library of the Middle East (DLME)"
-authors = ["Aaron Collier <aaron.collier@stanford.edu>"]
-license = "Apache2"
+authors = [
+    { name = "Aaron Collier", email = "aaron.collier@stanford.edu" },
+    { name = "Jacob Hill", email = "jtim@stanford.edu" }
+]
+license = { text = "Apache2" }
 requires-python = ">= 3.12"
 dependencies = [
     "aiohttp",
@@ -30,7 +33,7 @@ pythonpath = ["."]
 addopts = "-v"
 
 [tool.setuptools]
-py-modules = []
+packages = ["dlme_airflow"]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
These are a few small changes to our `pyproject.toml` file so that uv is happier about running scripts in the bin subdirectory.

I think going forward we may want to move the utilities into the dlme_airflow module, and then add them to the `pyproject.toml` file as scripts:

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#creating-executable-scripts

Fixes #553
