### PR TITLE
adjust Penn thumbnail fetching due to data changes on their end

### DIFF
--- a/dlme_airflow/utils/add_thumbnails.py
+++ b/dlme_airflow/utils/add_thumbnails.py
@@ -2,6 +2,7 @@
 import os
 import pandas
 import logging
+import json
 
 from typing import Optional
 from dlme_airflow.utils.schema import get_schema
@@ -21,14 +22,18 @@ def add_thumbnails(**kwargs) -> None:
 
     # add a thumbnail column and save it
     df = pandas.read_csv(working_csv)
-    df["thumbnail"] = df.url.apply(get_thumbnail)
+    df["thumbnail"] = df.emuIRN.apply(get_thumbnail)
     df.to_csv(working_csv)
 
 
-def get_thumbnail(url) -> Optional[str]:
+def get_thumbnail(id) -> Optional[str]:
+    url = f"https://www.penn.museum/collections/object/{id}"
     logging.info(f"getting thumbnail for {url}")
-    schema = get_schema(url)
-    if schema:
-        return schema.get("thumbnailUrl")
-    else:
-        return None
+    try:
+        schema = get_schema(url)
+        if schema:
+            return schema.get("thumbnailUrl")
+        else:
+            return None
+    except json.JSONDecodeError as e:
+        logging.error(f"JSONDecodeError occurred: %s for record {url}", e)

--- a/tests/data/csv/penn.csv
+++ b/tests/data/csv/penn.csv
@@ -1,0 +1,4 @@
+,emuIRN,thumbnail
+0,1,http://thumbnail1.jpg
+1,2,http://thumbnail2.jpg
+2,3,http://thumbnail3.jpg

--- a/tests/utils/test_add_thumbnails.py
+++ b/tests/utils/test_add_thumbnails.py
@@ -6,7 +6,6 @@ import os
 from unittest.mock import patch
 from dlme_airflow.utils.add_thumbnails import add_thumbnails, get_thumbnail
 
-print(os.environ['PYTHONPATH'])
 
 @pytest.fixture
 def mock_collection():
@@ -26,7 +25,6 @@ def test_add_thumbnails_success(mock_collection, monkeypatch):
 
     monkeypatch.setattr('dlme_airflow.utils.add_thumbnails.get_thumbnail', mock_get_thumbnail)
     monkeypatch.setattr('pandas.read_csv', lambda file: pd.DataFrame({'emuIRN': ['1', '2', '3']}))
-    monkeypatch.setattr('pandas.DataFrame.to_csv', lambda self, path: print(f"Mock to_csv called with:\n{self}"))
 
     add_thumbnails(collection=mock_collection)
 

--- a/tests/utils/test_add_thumbnails.py
+++ b/tests/utils/test_add_thumbnails.py
@@ -1,7 +1,6 @@
 import pytest
 import pandas as pd
 import json
-import os
 
 from unittest.mock import patch
 from dlme_airflow.utils.add_thumbnails import add_thumbnails, get_thumbnail

--- a/tests/utils/test_add_thumbnails.py
+++ b/tests/utils/test_add_thumbnails.py
@@ -1,0 +1,69 @@
+import pytest
+import pandas as pd
+import json
+import os
+
+from unittest.mock import patch
+from dlme_airflow.utils.add_thumbnails import add_thumbnails, get_thumbnail
+
+print(os.environ['PYTHONPATH'])
+
+@pytest.fixture
+def mock_collection():
+    class MockCollection:
+        def data_path(self):
+            return '/mock/path'
+
+        def datafile(self, filetype):
+            return 'tests/data/csv/penn.csv'
+
+    return MockCollection()
+
+
+def test_add_thumbnails_success(mock_collection, monkeypatch):
+    def mock_get_thumbnail(id):
+        return f'http://thumbnail{id}.jpg'
+
+    monkeypatch.setattr('dlme_airflow.utils.add_thumbnails.get_thumbnail', mock_get_thumbnail)
+    monkeypatch.setattr('pandas.read_csv', lambda file: pd.DataFrame({'emuIRN': ['1', '2', '3']}))
+    monkeypatch.setattr('pandas.DataFrame.to_csv', lambda self, path: print(f"Mock to_csv called with:\n{self}"))
+
+    add_thumbnails(collection=mock_collection)
+
+    # Load the mocked DataFrame to assert
+    df = pd.DataFrame({
+        'emuIRN': ['1', '2', '3'],
+        'thumbnail': ['http://thumbnail1.jpg', 'http://thumbnail2.jpg', 'http://thumbnail3.jpg']
+    })
+
+    # Assertions
+    expected_thumbnails = ['http://thumbnail1.jpg', 'http://thumbnail2.jpg', 'http://thumbnail3.jpg']
+    pd.testing.assert_series_equal(df["thumbnail"], pd.Series(expected_thumbnails), check_names=False)
+
+
+
+def test_get_thumbnail_success():
+    # Mock the schema response
+    with patch('dlme_airflow.utils.add_thumbnails.get_schema', return_value={"thumbnailUrl": "http://thumbnail.jpg"}):
+        result = get_thumbnail('123')
+
+        # Assertions
+        assert result == "http://thumbnail.jpg"
+
+
+def test_get_thumbnail_no_schema():
+    # Mock the schema response as None
+    with patch('dlme_airflow.utils.add_thumbnails.get_schema', return_value=None):
+        result = get_thumbnail('123')
+
+        # Assertions
+        assert result is None
+
+
+def test_get_thumbnail_json_decode_error():
+    # Simulate a JSON decode error
+    with patch('dlme_airflow.utils.add_thumbnails.get_schema', side_effect=json.JSONDecodeError("Expecting value", "doc", 0)):
+        result = get_thumbnail('123')
+
+        # Assertions
+        assert result is None


### PR DESCRIPTION
Penn Museum changed the way they share data and the columns available. The url column is no longer available but can be built with the uri so I added that logic to the `get_thumbnail` function and also added some error handling for JSONDecodeErrors since I encountered one during testing.