### PR TITLE
make Penn post harvest operate on json instead of csv

### DIFF
--- a/dlme_airflow/utils/add_thumbnails.py
+++ b/dlme_airflow/utils/add_thumbnails.py
@@ -23,7 +23,7 @@ def add_thumbnails(**kwargs) -> None:
     # add a thumbnail column and save it
     df = pandas.read_json(working_json)
     df["thumbnail"] = df.emuIRN.apply(get_thumbnail)
-    df.to_json(working_json)
+    df.to_json(working_json, orient="records")
 
 
 def get_thumbnail(id) -> Optional[str]:

--- a/dlme_airflow/utils/add_thumbnails.py
+++ b/dlme_airflow/utils/add_thumbnails.py
@@ -15,15 +15,15 @@ def add_thumbnails(**kwargs) -> None:
     if data_path is None:
         raise Exception(f"unable to find data_path for collection={coll}")
 
-    # ensure that the working csv is present on the filesystem
-    working_csv = coll.datafile("csv")
-    if not os.path.isfile(working_csv):
-        raise Exception(f"unable to locate working CSV data: {working_csv}")
+    # ensure that the working json is present on the filesystem
+    working_json = coll.datafile("json")
+    if not os.path.isfile(working_json):
+        raise Exception(f"unable to locate working json data: {working_json}")
 
     # add a thumbnail column and save it
-    df = pandas.read_csv(working_csv)
+    df = pandas.read_json(working_json)
     df["thumbnail"] = df.emuIRN.apply(get_thumbnail)
-    df.to_csv(working_csv)
+    df.to_json(working_json)
 
 
 def get_thumbnail(id) -> Optional[str]:

--- a/tests/data/csv/penn.csv
+++ b/tests/data/csv/penn.csv
@@ -1,4 +1,0 @@
-,emuIRN,thumbnail
-0,1,http://thumbnail1.jpg
-1,2,http://thumbnail2.jpg
-2,3,http://thumbnail3.jpg

--- a/tests/data/json/penn.json
+++ b/tests/data/json/penn.json
@@ -1,0 +1,1 @@
+[{"emuIRN":"1","thumbnail":"http:\/\/thumbnail1.jpg"},{"emuIRN":"2","thumbnail":"http:\/\/thumbnail2.jpg"},{"emuIRN":"3","thumbnail":"http:\/\/thumbnail3.jpg"}]

--- a/tests/utils/test_add_thumbnails.py
+++ b/tests/utils/test_add_thumbnails.py
@@ -13,7 +13,7 @@ def mock_collection():
             return '/mock/path'
 
         def datafile(self, filetype):
-            return 'tests/data/csv/penn.csv'
+            return 'tests/data/json/penn.json'
 
     return MockCollection()
 
@@ -23,7 +23,7 @@ def test_add_thumbnails_success(mock_collection, monkeypatch):
         return f'http://thumbnail{id}.jpg'
 
     monkeypatch.setattr('dlme_airflow.utils.add_thumbnails.get_thumbnail', mock_get_thumbnail)
-    monkeypatch.setattr('pandas.read_csv', lambda file: pd.DataFrame({'emuIRN': ['1', '2', '3']}))
+    monkeypatch.setattr('pandas.read_json', lambda file: pd.DataFrame({'emuIRN': ['1', '2', '3']}))
 
     add_thumbnails(collection=mock_collection)
 


### PR DESCRIPTION
This never got updated when we moved over to operating on json instead of csv so the thumbnails from the Penn post harvest task didn't show up, fixes https://github.com/sul-dlss/dlme-airflow/issues/568.