### PR TITLE
Add basic paging to the XML driver

### DIFF
--- a/catalogs/newcastle.yaml
+++ b/catalogs/newcastle.yaml
@@ -55,4 +55,7 @@ sources:
           path: ".//type"
           optional: true
     args:
-      collection_url: https://gertrudebell.ncl.ac.uk/export/
+      collection_url: https://gertrudebell.ncl.ac.uk/export?resumptionToken={offset}
+      paging:
+        resumptionToken: True
+        increment: 0

--- a/catalogs/shahre_farang.yaml
+++ b/catalogs/shahre_farang.yaml
@@ -96,7 +96,9 @@ sources:
             media: "http://search.yahoo.com/mrss/"
           optional: true
     args:
-      collection_url: http://shahrefarang.com/en/feed/
+      collection_url: http://shahrefarang.com/en/feed/?paged={offset}
+      paging:
+        increment: 1
   persian:
     description: "Shahre Farang"
     driver: xml
@@ -143,4 +145,6 @@ sources:
             media: "http://search.yahoo.com/mrss/"
           optional: true
     args:
-      collection_url: http://shahrefarang.com/feed/
+      collection_url: http://shahrefarang.com/feed//?paged={offset}
+      paging:
+        increment: 1

--- a/dlme_airflow/drivers/xml.py
+++ b/dlme_airflow/drivers/xml.py
@@ -16,11 +16,11 @@ class XmlSource(intake.source.base.DataSource):
     version = "0.0.2"
     partition_access = True
 
-    def __init__(self, collection_url, paging=None, dtype=None, metadata=None):
+    def __init__(self, collection_url, paging={}, dtype=None, metadata=None):
         super(XmlSource, self).__init__(metadata=metadata)
         self.collection_url = collection_url
         self.paging_config = paging
-        self.paging_increment = 0
+        self.paging_increment = paging.get("increment", 1)
         self._record_selector = self._get_record_selector()
         self._path_expressions = self._get_path_expressions()
         self._records = []
@@ -37,36 +37,26 @@ class XmlSource(intake.source.base.DataSource):
             self._records.append(record)
 
     def _open_paged_collection(self):
-        if "increment" not in self.paging_config:
-            self.paging_increment = 0
-        else:
-            self.paging_increment = self.paging_config["increment"]
-
-        while True:
-            collection_url = self._get_collection_url(self.paging_increment)
-            collection_result = self._fetch_collection(collection_url)
-
-            if len(collection_result) == 0:
-                break
-
-            xtree = etree.fromstring(collection_result)
-            record_elements = self._get_record_elements(xtree)
-
-            if not record_elements:
-                break
-
+        for record_elements in self._fetch_collection():
             self._process_records(record_elements)
-
-            if not self._update_paging_config(xtree):
-                break
 
     def _get_collection_url(self, offset):
         """Generate the collection URL with the current offset."""
         return self.collection_url.format(offset=offset)
 
-    def _fetch_collection(self, url):
+    def _fetch_collection(self):
         """Fetch the content of the collection URL."""
-        return requests.get(url).content
+        records = []
+        try:
+            while True:
+                collection_url = self._get_collection_url(self.paging_increment)
+                collection_result = requests.get(collection_url).content
+                xtree = etree.fromstring(collection_result)
+                records.append(self._get_record_elements(xtree))
+                self._set_offset(xtree)
+        except etree.XMLSyntaxError:
+            # If the XML is malformed or empty, we stop fetching and return the records
+            return records
 
     def _get_record_elements(self, xtree):
         """Find record elements in the XML tree."""
@@ -80,24 +70,20 @@ class XmlSource(intake.source.base.DataSource):
             record = self._construct_fields(record_el)
             self._records.append(record)
 
-    def _update_paging_config(self, xtree):
+    def _set_offset(self, xtree):
         """
-        Update the paging configuration using the resumption token, if available.
+        Sets the offset based on the current increment or presence of a resumption token.
+        """
+        self.paging_increment += self.paging_config.get("increment", 0)
 
-        Returns:
-            bool: True if paging should continue, False otherwise.
-        """
         if "resumptionToken" in self.paging_config:
-            resumption_token_elements = xtree.xpath(".//resumptionToken")
-            if resumption_token_elements:
-                _, token = resumption_token_elements[0].text.split("=")
-                self.paging_increment = int(token)
-                return True
-            else:
-                return False
-        else:
-            self.paging_increment += self.paging_config.get("increment", 1)
-            return True
+            if xtree is not None:
+                resumption_token = xtree.xpath(".//resumptionToken")
+                if resumption_token:
+                    _, token = resumption_token[0].text.split("=")
+                    self.paging_increment = int(token)
+                else:
+                    raise Exception("Missing resumption token")
 
     def _construct_fields(self, record_el: etree) -> dict:
         record: Dict[str, (str | List)] = {}

--- a/tests/data/xml/paged/page_1.xml
+++ b/tests/data/xml/paged/page_1.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+	xmlns:media="http://search.yahoo.com/mrss/">
+
+<channel>
+	<title>ShahreFarang</title>
+	<atom:link href="https://shahrefarang.com/en/feed/" rel="self" type="application/rss+xml" />
+	<link>https://shahrefarang.com/en/</link>
+	<description>شهرفرنگ</description>
+	<lastBuildDate>Thu, 24 Feb 2022 14:52:19 +0000</lastBuildDate>
+	<language>en-US</language>
+	<sy:updatePeriod>
+	hourly	</sy:updatePeriod>
+	<sy:updateFrequency>
+	1	</sy:updateFrequency>
+	<generator>https://wordpress.org/?v=6.0.9</generator>
+	<item>
+		<title>Plasco Building, Tehran</title>
+		<link>https://shahrefarang.com/en/plasco-tehran/</link>
+					<comments>https://shahrefarang.com/en/plasco-tehran/#comments</comments>
+
+		<dc:creator><![CDATA[سورنا پرهام]]></dc:creator>
+		<pubDate>Fri, 20 Jan 2017 06:38:34 +0000</pubDate>
+				<category><![CDATA[Architecture]]></category>
+		<category><![CDATA[Nostalgia]]></category>
+		<category><![CDATA[تهران]]></category>
+		<category><![CDATA[خیابان]]></category>
+		<category><![CDATA[ساختمان]]></category>
+		<category><![CDATA[مناظر شهری]]></category>
+		<guid isPermaLink="false">http://shahrefarang.com/?p=23291/</guid>
+
+					<description><![CDATA[The Plasco Building was a 17-story high-rise in Tehran. It was built in 1962 by the prominent Iranian Jewish businessman Habib Elghanian, and it was named after his plastics company. The building was the tallest building in Iran when it was constructed, and it was considered an iconic landmark of the Tehran skyline. The Plasco building collapsed on January 19, 2017, during a fire.]]></description>
+
+					<wfw:commentRss>https://shahrefarang.com/en/plasco-tehran/feed/</wfw:commentRss>
+			<slash:comments>1</slash:comments>
+
+
+
+		<media:content url="https://shahrefarang.com/wp-content/uploads/2017/01/plasco-101-712x742.jpg" type="image/jpeg" medium="image" width="100%" height="auto">
+				<media:description type="plain"><![CDATA[plasco-101]]></media:description>
+		</media:content>	</item>
+		<item>
+		<title>1920s Vintage Ads in Iranian Newspapers</title>
+		<link>https://shahrefarang.com/en/iran-ads-1920s-2/</link>
+					<comments>https://shahrefarang.com/en/iran-ads-1920s-2/#respond</comments>
+
+		<dc:creator><![CDATA[شهرفرنگ]]></dc:creator>
+		<pubDate>Mon, 05 Dec 2016 19:29:44 +0000</pubDate>
+				<category><![CDATA[Everyday Life]]></category>
+		<category><![CDATA[Fashion]]></category>
+		<category><![CDATA[Literature]]></category>
+		<category><![CDATA[Nostalgia]]></category>
+		<category><![CDATA[Advertisement]]></category>
+		<category><![CDATA[Car]]></category>
+		<category><![CDATA[Clothing]]></category>
+		<guid isPermaLink="false">http://shahrefarang.com/en/?p=23059</guid>
+
+					<description><![CDATA[Advertising in Iranian newspapers was a new phenomenon in the late 1920s. Advertisements introduced Iranians to some other new phenomena such as cars, radio, instant cameras, and the European-style outfit that revolutionized how Iranians lived and interacted with each other.
+The ads here are selected from the newspapers published between 1926 to 1931. ]]></description>
+
+					<wfw:commentRss>https://shahrefarang.com/en/iran-ads-1920s-2/feed/</wfw:commentRss>
+			<slash:comments>0</slash:comments>
+
+
+
+		<media:content url="https://shahrefarang.com/wp-content/uploads/2016/11/ads-rezashah-header-1-712x324.jpg" type="image/jpeg" medium="image" width="100%" height="auto">
+				<media:description type="plain"><![CDATA[ads-rezashah-header]]></media:description>
+		</media:content>	</item>
+	</channel>
+</rss>

--- a/tests/data/xml/paged/page_2.xml
+++ b/tests/data/xml/paged/page_2.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+	xmlns:media="http://search.yahoo.com/mrss/">
+
+<channel>
+	<title>Page 2 | ShahreFarang</title>
+	<atom:link href="https://shahrefarang.com/en/feed/?paged=2" rel="self" type="application/rss+xml" />
+	<link>https://shahrefarang.com/en/</link>
+	<description>شهرفرنگ</description>
+	<lastBuildDate>Thu, 05 Apr 2018 19:31:16 +0000</lastBuildDate>
+	<language>en-US</language>
+	<sy:updatePeriod>
+	hourly	</sy:updatePeriod>
+	<sy:updateFrequency>
+	1	</sy:updateFrequency>
+	<generator>https://wordpress.org/?v=6.0.9</generator>
+	<item>
+		<title>Ettelaat Daily’s Old Building</title>
+		<link>https://shahrefarang.com/en/ettelaat-dailys-old-building/</link>
+					<comments>https://shahrefarang.com/en/ettelaat-dailys-old-building/#respond</comments>
+
+		<dc:creator><![CDATA[شهرفرنگ]]></dc:creator>
+		<pubDate>Thu, 30 Jan 2014 21:17:46 +0000</pubDate>
+				<category><![CDATA[Architecture]]></category>
+		<category><![CDATA[Building]]></category>
+		<category><![CDATA[Press]]></category>
+		<category><![CDATA[Tehran]]></category>
+		<guid isPermaLink="false">http://shahrefarang.com/ettelaat-dailys-old-building/</guid>
+
+					<description><![CDATA[The old headquarters of Ettelaat publishing company from the 1930s is located in Khayam Street, Tehran. Ettelaat newspaper is the oldest Iranian newspaper in Persian, still being published.]]></description>
+
+					<wfw:commentRss>https://shahrefarang.com/en/ettelaat-dailys-old-building/feed/</wfw:commentRss>
+			<slash:comments>0</slash:comments>
+
+
+
+		<media:content url="https://shahrefarang.com/wp-content/uploads/2014/01/Ettelaat-10-570x850.jpg" type="image/jpeg" medium="image" width="100%" height="auto">
+				<media:description type="plain"><![CDATA[Old Ettelaat Building in Tehran]]></media:description>
+		</media:content>	</item>
+		<item>
+		<title>Iran National Football Team</title>
+		<link>https://shahrefarang.com/en/iran-national-football-team-2/</link>
+					<comments>https://shahrefarang.com/en/iran-national-football-team-2/#respond</comments>
+
+		<dc:creator><![CDATA[Mehrdad]]></dc:creator>
+		<pubDate>Wed, 22 Jan 2014 16:39:03 +0000</pubDate>
+				<category><![CDATA[Nostalgia]]></category>
+		<category><![CDATA[soccer]]></category>
+		<category><![CDATA[Sport]]></category>
+		<guid isPermaLink="false">http://shahrefarang.com/iran-national-football-team-2/</guid>
+
+					<description><![CDATA[The national football (soccer) team of Iran, known in Persian as Team Melli, ranks 1st in Asia and 33rd in the world according to the December 2013 FIFA World Rankings.]]></description>
+
+					<wfw:commentRss>https://shahrefarang.com/en/iran-national-football-team-2/feed/</wfw:commentRss>
+			<slash:comments>0</slash:comments>
+
+
+
+		<media:content url="https://shahrefarang.com/wp-content/uploads/2014/01/team-melli-cover-712x543.jpg" type="image/jpeg" medium="image" width="100%" height="auto">
+				<media:description type="plain"><![CDATA[The national football team of Iran]]></media:description>
+		</media:content>	</item>
+	</channel>
+</rss>

--- a/tests/data/xml/paged/resumption_token_1.xml
+++ b/tests/data/xml/paged/resumption_token_1.xml
@@ -1,0 +1,11 @@
+<response>
+  <responseDate>2025-01-13T06:10:21Z</responseDate>
+  <items>
+    <item>
+      <node_id>1</node_id>
+      <title>First page of records</title>
+      <type>record</type>
+    </item>
+  </items>
+  <resumptionToken>/export?resumptionToken=2</resumptionToken>
+</response>

--- a/tests/data/xml/paged/resumption_token_2.xml
+++ b/tests/data/xml/paged/resumption_token_2.xml
@@ -1,0 +1,10 @@
+<response>
+  <responseDate>2025-01-13T06:10:21Z</responseDate>
+  <items>
+    <item>
+      <node_id>2</node_id>
+      <title>Second page of records</title>
+      <type>record</type>
+    </item>
+  </items>
+</response>

--- a/tests/drivers/test_xml.py
+++ b/tests/drivers/test_xml.py
@@ -151,3 +151,36 @@ def test_paged_xml(requests_mock):
     assert df.title[1] == "1920s Vintage Ads in Iranian Newspapers"
     assert df.title[2] == "Ettelaat Daily’s Old Building"
     assert df.title[3] == "Iran National Football Team"
+
+def test_resumptionToken_paged_xml(requests_mock):
+    requests_mock.get(
+        "https://example.com/export?resumptionToken=0",
+        text=open("tests/data/xml/paged/resumption_token_1.xml", "r").read(),
+        headers={"Accept": "application/text+xml"},
+    )
+
+    requests_mock.get(
+        "https://example.com/export?resumptionToken=2",
+        text=open("tests/data/xml/paged/resumption_token_2.xml", "r").read(),
+        headers={"Accept": "application/text+xml"},
+    )
+
+    metadata = {
+        "record_selector": {"path": ".//item", "namespace": None},
+        "fields": {
+            "id": {"path": ".//node_id", "namespace": None},
+            "title": {"path": ".//title", "namespace": None},
+            "type": {"path": ".//type", "namespace": None},
+        },
+    }
+
+    source = XmlSource(
+        collection_url="https://example.com/export?resumptionToken={offset}",
+        metadata=metadata,
+        paging={"resumptionToken": True, "increment": 0},
+    )
+
+    df = source.read()
+    assert(len(df) == 2)
+    assert df.title[0] == 'First page of records'
+    assert df.title[1] == "Second page of records"

--- a/tests/drivers/test_xml.py
+++ b/tests/drivers/test_xml.py
@@ -106,3 +106,48 @@ def test_multi_field(requests_mock):
     assert len(df) == 2
     assert df.name[0] == ["Donna Haraway", "bell hooks"]
     assert df.name[1] == ["Elinor Ostrom", "Ivan Illich"]
+
+
+def test_paged_xml(requests_mock):
+    requests_mock.get(
+        "https://example.com/?paged=1",
+        text=open("tests/data/xml/paged/page_1.xml", "r").read(),
+        headers={"Accept": "application/text+xml"},
+    )
+
+    requests_mock.get(
+        "https://example.com/?paged=2",
+        text=open("tests/data/xml/paged/page_2.xml", "r").read(),
+        headers={"Accept": "application/text+xml"},
+    )
+
+    requests_mock.get(
+        "https://example.com/?paged=3",
+        text=None,
+        headers={"Accept": "application/text+xml"},
+    )
+
+    metadata = {
+        "record_selector": {"path": ".//item", "namespace": None},
+        "fields": {
+            "id": {"path": ".//guid", "namespace": None},
+            "title": {
+                "path": ".//title",
+                "namespace": None,
+            },
+            "creator": {"path": ".//dc:creator", "namespace": {"dc": "http://purl.org/dc/elements/1.1/"}},
+        },
+    }
+
+    source = XmlSource(
+        collection_url="https://example.com/?paged={offset}",
+        metadata=metadata,
+        paging={"increment": 1},
+    )
+
+    df = source.read()
+    assert(len(df) == 4)
+    assert df.title[0] == 'Plasco Building, Tehran'
+    assert df.title[1] == "1920s Vintage Ads in Iranian Newspapers"
+    assert df.title[2] == "Ettelaat Daily’s Old Building"
+    assert df.title[3] == "Iran National Football Team"


### PR DESCRIPTION
Fixes #428 

This adds basic paging either by a numeric increment or `resumptionToken` to the custom XML driver.