### PR TITLE
Automate OPenn - scrape HTML for record links

### DIFF
--- a/catalogs/catalog.yaml
+++ b/catalogs/catalog.yaml
@@ -139,6 +139,12 @@ sources:
     description: Open Islamicate Text Initiative
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}
+  openn:
+    args:
+      path: catalogs/openn.yaml
+    description: University of Pennsylvania and Penn Museum - Muslim World
+    driver: intake.catalog.local.YAMLFileCatalog
+    metadata: {}
   penn:
     args:
       path: catalogs/penn.yaml

--- a/catalogs/openn.yaml
+++ b/catalogs/openn.yaml
@@ -1,0 +1,48 @@
+metadata:
+  version: 1
+  data_path: openn
+  schedule: "0 15 25 Jan,Oct *"
+sources:
+  muslim_world:
+    description: University of Pennsylvania Libraries - Manuscripts of the Muslim World
+    driver: xml
+    metadata:
+      data_path: openn/muslim_world
+      output_format: json
+      config: openn
+      fields:
+        title:
+          path: '/tei:TEI/tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title'
+          namespace:
+            tei: 'http://www.tei-c.org/ns/1.0'
+          optional: false
+        contributor:
+          path: '/tei:TEI/tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:resp/tei:persName'
+          namespace:
+            tei: 'http://www.tei-c.org/ns/1.0'
+          optional: true
+        publisher:
+          path: '/tei:TEI/tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:publisher'
+          namespace:
+            tei: 'http://www.tei-c.org/ns/1.0'
+          optional: true
+        note:
+          path: '/tei:TEI/tei:teiHeader/tei:fileDesc/tei:notesStmt/tei:note'
+          namespace:
+            tei: 'http://www.tei-c.org/ns/1.0'
+          optional: true
+        date:
+          path: '/tei:TEI/tei:teiHeader/tei:sourceDesc/tei:msDesc/tei:history/tei:origin/tei:p'
+          namespace:
+            tei: 'http://www.tei-c.org/ns/1.0'
+          optional: true
+        provenance:
+          path: '/tei:TEI/tei:teiHeader/tei:sourceDesc/tei:msDesc/tei:history/tei:provenance'
+          namespace:
+            tei: 'http://www.tei-c.org/ns/1.0'
+          optional: true
+    args:
+      collection_url: https://openn.library.upenn.edu/html/muslimworld_contents.html
+      paging:
+        link_text: TEI XML
+        base_url: https://openn.library.upenn.edu

--- a/dlme_airflow/utils/partition_url_builder.py
+++ b/dlme_airflow/utils/partition_url_builder.py
@@ -22,6 +22,7 @@ class PartitionBuilder:
         self.data = []
 
     def urls(self):
+        partition_urls = []
         if self.paging_config.get("pages_url"):
             return self._prefetch_page_urls()
 
@@ -34,11 +35,11 @@ class PartitionBuilder:
 
         self.provider_data = self._fetch_provider_data(self.collection_url)
         if self.paging_config.get("increment"):
-            return self._calculate_partitions()
+            partition_urls = self._calculate_partitions()
         elif self.paging_config.get("urls"):
-            return self._urls_from_provider()
+            partition_urls = self._urls_from_provider()
 
-        return []
+        return partition_urls
 
     def records(self):
         if self.paging_config.get("pages_url"):

--- a/dlme_airflow/utils/partition_url_builder.py
+++ b/dlme_airflow/utils/partition_url_builder.py
@@ -2,6 +2,8 @@ import requests
 import jsonpath_ng
 import validators
 
+from bs4 import BeautifulSoup
+
 class PartitionBuilder:
     """Determine the method used to extract or format the
     page queries when provider API requires paging.
@@ -22,6 +24,13 @@ class PartitionBuilder:
     def urls(self):
         if self.paging_config.get("pages_url"):
             return self._prefetch_page_urls()
+
+        if self.paging_config.get("link_text"):
+            link_text = self.paging_config["link_text"]
+            response = requests.get(self.collection_url)
+            soup = BeautifulSoup(response.content, "html.parser")
+            links = soup.find_all('a', string=link_text)
+            return [self.paging_config.get("base_url") + link['href'] for link in links]
 
         self.provider_data = self._fetch_provider_data(self.collection_url)
         if self.paging_config.get("increment"):

--- a/tests/data/xml/paged/collection.html
+++ b/tests/data/xml/paged/collection.html
@@ -1,0 +1,19 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>My Collection</title>
+  </head>
+
+  <body>
+    <ul class="ul_documents">
+      <li>
+        <span class="page-link"><a href="/record_1.xml">TEI XML</a></span>
+      </li>
+      <li>
+        <span class="page-link"><a href="/record_2.xml">TEI XML</a></span>
+      </li>
+    </ul>
+  </body>
+</html>

--- a/tests/data/xml/paged/record_1.xml
+++ b/tests/data/xml/paged/record_1.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<TEI>
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title 1</title>
+      </titleStmt>
+    </fileDesc>
+  </teiHeader>
+</TEI>

--- a/tests/data/xml/paged/record_2.xml
+++ b/tests/data/xml/paged/record_2.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<TEI>
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title 2</title>
+      </titleStmt>
+    </fileDesc>
+  </teiHeader>
+</TEI>

--- a/tests/drivers/test_xml.py
+++ b/tests/drivers/test_xml.py
@@ -216,3 +216,40 @@ def test_pagination_paged_xml(requests_mock):
     assert(len(df) == 2)
     assert df.title[0] == 'Title 1'
     assert df.title[1] == "Title 2"
+
+
+def test_parse_record_urls_xml(requests_mock):
+    requests_mock.get(
+        "https://example.com/collection.html",
+        text=open("tests/data/xml/paged/collection.html", "r").read(),
+        headers={"Accept": "application/html"},
+    )
+
+    requests_mock.get(
+        "https://example.com/record_1.xml",
+        text=open("tests/data/xml/paged/record_1.xml", "r").read(),
+        headers={"Accept": "application/text+xml"},
+    )
+
+    requests_mock.get(
+        "https://example.com/record_2.xml",
+        text=open("tests/data/xml/paged/record_2.xml", "r").read(),
+        headers={"Accept": "application/text+xml"},
+    )
+
+    metadata = {
+        "fields": {
+            "title": {"path": "/TEI/teiHeader/fileDesc/titleStmt/title"},
+        },
+    }
+
+    source = XmlSource(
+        collection_url="https://example.com/collection.html",
+        metadata=metadata,
+        paging={"link_text": "TEI XML", "base_url": "https://example.com"},
+    )
+
+    df = source.read()
+    assert(len(df) == 2)
+    assert df.title[0] == 'Title 1'
+    assert df.title[1] == "Title 2"


### PR DESCRIPTION
Fixes #526 

This adds a `link_text` option to the paging config and uses that data to scrape the collection_url for links based on the link_text value and return those URLs are records, then reads each URL into a record for building the dataframe.