### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -2,5 +2,3 @@
 
 # Roles are passed to docker-compose as profiles.
 server 'dlme-airflow-dev.stanford.edu', user: 'dlme', roles: %w[app]
-
-Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.