### PR TITLE
update Penn Museum catalog

### DIFF
--- a/catalogs/penn.yaml
+++ b/catalogs/penn.yaml
@@ -17,47 +17,42 @@ sources:
       config: penn_museum
       fields:
         id:
-          name_in_dataframe: "emuIRN"
-          path: "emuIRN"
+          name_in_dataframe: "Record URL"
+          path: "Record URL"
     args:
       urlpath:
-        - https://www.penn.museum/collections/assets/data/Penn_Museum_Collections_Data.csv
+        - https://collections.penn.museum/collections/assets/data/Penn_Museum_Collections_Data.csv
       csv_kwargs:
         dtype:
-          accession_credit_line: object
           creator: object
-          culture_area: object
+          cultureArea: object
           culture: object
-          curatorial_section: object
-          date_made_early: object
-          date_made_late: object
-          date_made: object
+          curatorialSection: object
+          creditLine: object
           dateMade: object
+          depth: object
           description: object
           earlyDate: object
-          emuIRN: object
           iconography: object
           iconographySubject: object
+          identifier: object
           inscriptionMarkLanguage: object
           lateDate: object
-          manufacture_locationlocus: object
+          length: object
+          locus: object
           material: object
-          measurement_height: object
-          measurement_length: object
-          measurement_outside_diameter: object
-          measurement_tickness: object
-          measurement_unit: object
-          measurement_width: object
-          native_name: object
-          object_name: object
-          object_number: object
-          other_numbers: object
+          measurementUnit: object
+          nativeName: object
+          objectName: object
+          outsideDiameter: object
           period: object
-          provenience: object
+          placeName: object
+          Record URL: object
           siteName: object
           technique: object
+          thickness: object
           title: object
-          url: object
+          weight: object
   egyptian:
     description: University of Pennsylvania Egyptian Museum
     driver: sequential_csv
@@ -72,47 +67,42 @@ sources:
       config: penn_museum
       fields:
         id:
-          name_in_dataframe: "emuIRN"
-          path: "emuIRN"
+          name_in_dataframe: "Record URL"
+          path: "Record URL"
     args:
       urlpath:
-        - https://www.penn.museum/collections/assets/data/Penn_Museum_Collections_Data.csv
+        - https://collections.penn.museum/collections/assets/data/Penn_Museum_Collections_Data.csv
       csv_kwargs:
         dtype:
-          accession_credit_line: object
           creator: object
-          culture_area: object
+          cultureArea: object
           culture: object
-          curatorial_section: object
-          date_made_early: object
-          date_made_late: object
-          date_made: object
+          curatorialSection: object
+          creditLine: object
           dateMade: object
+          depth: object
           description: object
           earlyDate: object
-          emuIRN: object
           iconography: object
           iconographySubject: object
+          identifier: object
           inscriptionMarkLanguage: object
           lateDate: object
-          manufacture_locationlocus: object
+          length: object
+          locus: object
           material: object
-          measurement_height: object
-          measurement_length: object
-          measurement_outside_diameter: object
-          measurement_tickness: object
-          measurement_unit: object
-          measurement_width: object
-          native_name: object
-          object_name: object
-          object_number: object
-          other_numbers: object
+          measurementUnit: object
+          nativeName: object
+          objectName: object
+          outsideDiameter: object
           period: object
-          provenience: object
+          placeName: object
+          Record URL: object
           siteName: object
           technique: object
+          thickness: object
           title: object
-          url: object
+          weight: object
   near_eastern:
     description: University of Pennsylvania Near Eastern Museum
     driver: sequential_csv
@@ -127,44 +117,39 @@ sources:
       config: penn_museum
       fields:
         id:
-          name_in_dataframe: "emuIRN"
-          path: "emuIRN"
+          name_in_dataframe: "Record URL"
+          path: "Record URL"
     args:
       urlpath:
-        - https://www.penn.museum/collections/assets/data/Penn_Museum_Collections_Data.csv
+        - https://collections.penn.museum/collections/assets/data/Penn_Museum_Collections_Data.csv
       csv_kwargs:
         dtype:
-          accession_credit_line: object
           creator: object
-          culture_area: object
+          cultureArea: object
           culture: object
-          curatorial_section: object
-          date_made_early: object
-          date_made_late: object
-          date_made: object
+          curatorialSection: object
+          creditLine: object
           dateMade: object
+          depth: object
           description: object
           earlyDate: object
-          emuIRN: object
           iconography: object
           iconographySubject: object
+          identifier: object
           inscriptionMarkLanguage: object
           lateDate: object
-          manufacture_locationlocus: object
+          length: object
+          locus: object
           material: object
-          measurement_height: object
-          measurement_length: object
-          measurement_outside_diameter: object
-          measurement_tickness: object
-          measurement_unit: object
-          measurement_width: object
-          native_name: object
-          object_name: object
-          object_number: object
-          other_numbers: object
+          measurementUnit: object
+          nativeName: object
+          objectName: object
+          outsideDiameter: object
           period: object
-          provenience: object
+          placeName: object
+          Record URL: object
           siteName: object
           technique: object
+          thickness: object
           title: object
-          url: object
+          weight: object

--- a/dlme_airflow/utils/add_thumbnails.py
+++ b/dlme_airflow/utils/add_thumbnails.py
@@ -22,13 +22,13 @@ def add_thumbnails(**kwargs) -> None:
 
     # add a thumbnail column and save it
     df = pandas.read_json(working_json)
-    df["thumbnail"] = df.emuIRN.apply(get_thumbnail)
+    df["thumbnail"] = df["Record URL"].apply(get_thumbnail)
     df.dropna(subset=["thumbnail"], inplace=True)
     df.to_json(working_json, orient="records")
 
 
 def get_thumbnail(id) -> Optional[str]:
-    url = f"https://www.penn.museum/collections/object/{id}"
+    url = id
     logging.info(f"getting thumbnail for {url}")
     try:
         schema = get_schema(url)

--- a/tests/data/json/penn.json
+++ b/tests/data/json/penn.json
@@ -1,1 +1,1 @@
-[{"emuIRN":"1","thumbnail":"http:\/\/thumbnail1.jpg"},{"emuIRN":"2","thumbnail":"http:\/\/thumbnail2.jpg"},{"emuIRN":"3","thumbnail":"http:\/\/thumbnail3.jpg"}]
+[{"Record URL":"https://collections.penn.museum/collections/object/15390","thumbnail":"http:\/\/thumbnail1.jpg"},{"Record URL":"https://collections.penn.museum/collections/object/290403","thumbnail":"http:\/\/thumbnail2.jpg"},{"Record URL":"https://collections.penn.museum/collections/object/290370","thumbnail":"http:\/\/thumbnail3.jpg"}]

--- a/tests/utils/test_add_thumbnails.py
+++ b/tests/utils/test_add_thumbnails.py
@@ -23,13 +23,13 @@ def test_add_thumbnails_success(mock_collection, monkeypatch):
         return f'http://thumbnail{id}.jpg'
 
     monkeypatch.setattr('dlme_airflow.utils.add_thumbnails.get_thumbnail', mock_get_thumbnail)
-    monkeypatch.setattr('pandas.read_json', lambda file: pd.DataFrame({'emuIRN': ['1', '2', '3']}))
+    monkeypatch.setattr('pandas.read_json', lambda file: pd.DataFrame({'Record URL': ['1', '2', '3']}))
 
     add_thumbnails(collection=mock_collection)
 
     # Load the mocked DataFrame to assert
     df = pd.DataFrame({
-        'emuIRN': ['1', '2', '3'],
+        'Record URL': ['1', '2', '3'],
         'thumbnail': ['http://thumbnail1.jpg', 'http://thumbnail2.jpg', 'http://thumbnail3.jpg']
     })
 

--- a/tests/utils/test_schema.py
+++ b/tests/utils/test_schema.py
@@ -1,14 +1,12 @@
 from dlme_airflow.utils.schema import get_schema
 
 
-# Temporarily skip while penn.museum is blocked or broken while finding
-# new resources to use in this test
-# def test_get_schema():
-#     data = get_schema("https://www.penn.museum/collections/object/15390")
-#     assert (
-#         data["thumbnailUrl"]
-#         == "https://www.penn.museum//collections/assets/032T/327k/327554_800.jpg"
-#     )
+def test_get_schema():
+    data = get_schema("https://collections.penn.museum/collections/object/15390")
+    assert (
+        data["thumbnailUrl"]
+        == "https://www.penn.museum//collections/assets/032T/327k/327554_800.jpg"
+    )
 
 
 def test_no_schema():
@@ -23,8 +21,6 @@ def test_no_html():
     assert data is None
 
 
-# Temporarily skip while penn.museum is blocked or broken while finding
-# new resources to use in this test
-# def test_control_chars():
-#     data = get_schema("https://www.penn.museum/collections/object/46326")
-#     assert type(data) is dict
+def test_control_chars():
+    data = get_schema("https://collections.penn.museum/collections/object/46326")
+    assert type(data) is dict


### PR DESCRIPTION
Penn Museum moved the csv file to a different url and changed some of the field names. This PR brings the catalog up to date.